### PR TITLE
Faz o style-dictionary-build permitir categorias mais flexíveis

### DIFF
--- a/style-dictionary-build.js
+++ b/style-dictionary-build.js
@@ -1,47 +1,41 @@
 const StyleDictionary = require("style-dictionary");
 
-// these are the tokens we have in our stylesheet
-const DESIGN_TOKEN_NAMES_BY_TYPE = {
-  color: { presenterName: "Color", categoryName: "Colors" },
-  "font-family": { presenterName: "FontFamily", categoryName: "Font families" },
-  "font-weight": { presenterName: "FontWeight", categoryName: "Font weights" },
-  "font-size": { presenterName: "FontSize", categoryName: "Font sizes" },
-  "line-height": { presenterName: "LineHeight", categoryName: "Line heights" },
+// The storybook-design-token plugin expects the tokens to be split in categories separated by
+// headers on the SCSS file, so we generate it accordingly. The code based on the suggestion from
+// https://github.com/amzn/style-dictionary/issues/344#issuecomment-1200826141.
+const DESIGN_TOKEN_CATEGORIES_BY_PREFIX = {
+  color: { categoryName: "Colors", presenterName: "Color" },
 };
 
-// just get the token name from it, like: color
-const extractTokenNameFromDictionaryName = (variable) => {
+const extractTokenCategoryPrefix = (variable) => {
   if (variable) {
-    return Object.keys(DESIGN_TOKEN_NAMES_BY_TYPE).find((type) =>
-      variable.startsWith(type)
+    return Object.keys(DESIGN_TOKEN_CATEGORIES_BY_PREFIX).find((prefix) =>
+      variable.startsWith(prefix)
     );
   }
 };
 
-// Register your own format
+const formatCategory = ({ dictionary }) =>
+  Object.entries(DESIGN_TOKEN_CATEGORIES_BY_PREFIX).map(
+    ([prefix, names]) =>
+      `\n/**
+* @tokens ${names.categoryName}
+* @presenter ${names.presenterName}
+*/\n` +
+      dictionary.allTokens
+        .filter((token) => prefix === extractTokenCategoryPrefix(token.name))
+        .map((token) => `  --${token.name}: ${token.value};`)
+        .join("\n")
+  );
+
 StyleDictionary.registerFormat({
   name: `scss/variables-with-headers`,
   formatter: function ({ dictionary, file }) {
     return (
       StyleDictionary.formatHelpers.fileHeader({ file }) +
-      ":root {\n" +
-      Object.entries(DESIGN_TOKEN_NAMES_BY_TYPE)
-        .map(
-          ([type, names]) =>
-            `\n/**
-* @tokens ${names.categoryName}
-* @presenter ${names.presenterName}
-*/\n` +
-            dictionary.allTokens
-              .filter(
-                (token) =>
-                  type === extractTokenNameFromDictionaryName(token.name)
-              )
-              .map((token) => `--${token.name}: ${token.value};`)
-              .join("\n")
-        )
-        .join("\n") +
-      "}\n"
+      ":root {" +
+      formatCategory({ dictionary }).join("\n") +
+      "\n}\n"
     );
   },
 });


### PR DESCRIPTION
O style-dictionary-build.js supunha que as categorias dos tokens seriam sempre formadas pelo prefixo do nome anterior ao hífen. Por exemplo, um token `font-family-basic` seria classificado na categoria `font`. Mas na prática precisamos de mais granularidade; por exemplo precisamos de uma categoria para font family, já que é preciso usar [um presenter específico para isso](https://github.com/UX-and-I/storybook-design-token/tree/v3#available-presenters) no plugin de tokens do Storybook.

Para resolver isso, em vez de a extração da categoria ser automática a partir do nome, fiz uma declaração de categorias mais flexível no arquivo. Mas ela ainda não tem efeito prático por só existir a categoria de cores no momento; a utilidade deste commit virá posteriormente.