### PR TITLE
Renomeia font weight regular para normal

### DIFF
--- a/tokens/src/typography.json
+++ b/tokens/src/typography.json
@@ -10,7 +10,7 @@
       "bold": { "value": "bold" }
     },
     "style": {
-      "italic": { "value": "Italic" }
+      "italic": { "value": "italic" }
     },
     "size": {
       "xxxl": { "value": 32 },

--- a/tokens/src/typography.json
+++ b/tokens/src/typography.json
@@ -6,8 +6,8 @@
       "reading": { "value": "DroidSerif" }
     },
     "weight": {
-      "regular": { "value": "Regular" },
-      "bold": { "value": "Bold" }
+      "normal": { "value": "normal" },
+      "bold": { "value": "bold" }
     },
     "style": {
       "italic": { "value": "Italic" }


### PR DESCRIPTION
# Contexto
Como discutido em https://geekie.slack.com/archives/C0547M0UDHR/p1691695332042649 - Connect your Slack account , o valor que funciona tanto na web como no RN é normal e não regular.

# Mudanças
Alterei o valor e nome do token, de "Regular" para "normal".

# Como testar
verifique que, no storybook, o token continua documentado corretamente
