### PR TITLE
Ajusta tokens de line-height e cria helper de conversao para web-only

### DIFF
--- a/helpers/webOnlyHelpers.ts
+++ b/helpers/webOnlyHelpers.ts
@@ -1,4 +1,8 @@
+const toPx = (value: number): string => {
+  return `${value}px`;
+};
+
 // Essa função foi criada para resolver o uso do line-height em casos web-only
-export const convertToPx = (token: number): string => {
-  return `${token}px`;
+export const toWebToken = (token: number): string => {
+  return toPx(token);
 };

--- a/helpers/webOnlyHelpers.ts
+++ b/helpers/webOnlyHelpers.ts
@@ -1,0 +1,4 @@
+// Essa função foi criada para resolver o uso do line-height em casos web-only
+export const convertToPx = (token: number): string => {
+  return `${token}px`;
+};

--- a/stories/tokens/typographyTokens.stories.mdx
+++ b/stories/tokens/typographyTokens.stories.mdx
@@ -41,8 +41,12 @@ import typograpyTokens from '../../tokens/src/typography.json';
 ### Como usar tokens de line-height em casos web-only:
 
 Na web, em casos web-only, o valor do line-height pode ser tanto um valor absoluto, quanto um valor em pixels - `lineHeight: 26` e `lineHeight: 26px`, por exemplo - que resultam em formatações diferentes. O valor absoluto, de acordo com o mdn, na web, é multiplicado pelo tamanho da fonte.
+Vale ressaltar que os valores dos nossos tokens são em pixel, e, por isso, precisamos da adaptação da adição do px em casos web-only.
 
-Para esses casos, criamos a função _`convertToPx`_ - que pode ser usada no formato `line-height: convertToPx(DSA_LINE_HEIGHT_M)`.
+Para esses casos, criamos a função _`toWebToken`_ - que pode ser usada no formato `line-height: toWebToken(DSA_LINE_HEIGHT_M)`. Mas, essa adaptação não é necessária quando se usa um polyfill do RN num arquivo web.
+
+<br />
+<br />
 
 ## Letter spacing
 

--- a/stories/tokens/typographyTokens.stories.mdx
+++ b/stories/tokens/typographyTokens.stories.mdx
@@ -39,10 +39,10 @@ import typograpyTokens from '../../tokens/src/typography.json';
 <DesignTokenDocBlock categoryName="Line heights" showSearch={false} />
 
 ### Como usar tokens de line-height em casos web-only:
+
 Na web, em casos web-only, o valor do line-height pode ser tanto um valor absoluto, quanto um valor em pixels - `lineHeight: 26` e `lineHeight: 26px`, por exemplo - que resultam em formatações diferentes. O valor absoluto, de acordo com o mdn, na web, é multiplicado pelo tamanho da fonte.
 
-Para esses casos, criamos a função *`convertToPx`* - que pode ser usada no formato `line-height: convertToPx(DSA_LINE_HEIGHT_M)`.
-
+Para esses casos, criamos a função _`convertToPx`_ - que pode ser usada no formato `line-height: convertToPx(DSA_LINE_HEIGHT_M)`.
 
 ## Letter spacing
 

--- a/stories/tokens/typographyTokens.stories.mdx
+++ b/stories/tokens/typographyTokens.stories.mdx
@@ -38,6 +38,12 @@ import typograpyTokens from '../../tokens/src/typography.json';
 
 <DesignTokenDocBlock categoryName="Line heights" showSearch={false} />
 
+### Como usar tokens de line-height em casos web-only:
+Na web, em casos web-only, o valor do line-height pode ser tanto um valor absoluto, quanto um valor em pixels - `lineHeight: 26` e `lineHeight: 26px`, por exemplo - que resultam em formatações diferentes. O valor absoluto, de acordo com o mdn, na web, é multiplicado pelo tamanho da fonte.
+
+Para esses casos, criamos a função *`convertToPx`* - que pode ser usada no formato `line-height: convertToPx(DSA_LINE_HEIGHT_M)`.
+
+
 ## Letter spacing
 
 <DesignTokenDocBlock categoryName="Letter spacings" showSearch={false} />

--- a/tokens.ts
+++ b/tokens.ts
@@ -1,1 +1,2 @@
 export * from './build/tokens/ts/tokens';
+export * from './helpers/webOnlyHelpers';

--- a/tokens/config/style-dictionary-build.ts
+++ b/tokens/config/style-dictionary-build.ts
@@ -62,6 +62,7 @@ const formatCategory = ({ dictionary }: { dictionary: Dictionary }): string[] =>
           const tokenCategory = extractTokenCategoryPrefix(token.name);
           const unit =
             tokenCategory === 'DSA_FONT_SIZE' ||
+            tokenCategory === 'DSA_LINE_HEIGHT' ||
             tokenCategory === 'DSA_LETTER_SPACING'
               ? 'px'
               : '';

--- a/tokens/src/typography.json
+++ b/tokens/src/typography.json
@@ -24,10 +24,11 @@
     }
   },
   "line-height": {
-    "tight": { "value": "120%" },
-    "restrained": { "value": "130%" },
-    "moderate": { "value": "140%" },
-    "adequate": { "value": "150%" }
+    "xl": { "value": 38 },
+    "l": { "value": 32 },
+    "m": { "value": 26 },
+    "s": { "value": 20 },
+    "xs": { "value": 12 }
   },
   "letter-spacing": {
     "normal": { "value": 0.2 },


### PR DESCRIPTION
# Contexto
Os tokens de line height estão definidos como porcentagem, mas isso não é possível no RN.
Figma com os tokens: https://www.figma.com/file/CGaJEpou7a3NO8N5KX7CSL/Design-System?type=design&node-id=3014-5097&mode=dev

Ajustei os valores dos tokens, e como discutido [nessa thread](https://geekie.slack.com/archives/C300F0A4V/p1692294512354309), criei a função `convertToPx` para resolver o uso dos tokens em casos web-only.


# Mudanças
Os valores dos tokens de line-height foram alterados de valores relativos, para absolutos.
![Captura de Tela 2023-08-17 às 17 13 47](https://github.com/geekie/geekie-design-system/assets/29842092/5876e12d-b2bf-47bb-af7e-3c82f6f4daa9)
![Captura de Tela 2023-08-17 às 17 13 51](https://github.com/geekie/geekie-design-system/assets/29842092/32bc6d78-6d6a-4986-887d-f35896ccc6c7)


# Como testar
Verifique a documentação no storybook.