### PR TITLE
Adiciona pasta helpers para os arquivos do pacote

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "files": [
     "build/**",
+    "helpers/**",
     "token-presets/**",
     "tokens.ts"
   ],


### PR DESCRIPTION
# Contexto
A pasta helpers não estava exposta nos arquivos do pacote. Então, não era possível usar o helper `toWebToken`.

# Mudanças
Adicionei a pasta no arquivo `package.json`

# Como testar
