### PR TITLE
Documenta presets e adiciona helper para transformar presets para web

### DIFF
--- a/helpers/webOnlyHelpers.ts
+++ b/helpers/webOnlyHelpers.ts
@@ -11,15 +11,5 @@ export const toWebToken = (token: number): string => {
 
 // Essa função foi criada para resolver o uso dos presets em casos web-only
 export const toWebPreset = (preset: Preset): Preset => {
-  const webPreset = { ...preset };
-
-  (Object.keys(preset) as Array<keyof Preset>).map((style) => {
-    if (style === 'lineHeight') {
-      return (webPreset[style] = toPx(preset[style]));
-    } else {
-      return (webPreset[style] = preset[style] as string);
-    }
-  });
-
-  return webPreset;
+  return { ...preset, lineHeight: toPx(preset.lineHeight) };
 };

--- a/helpers/webOnlyHelpers.ts
+++ b/helpers/webOnlyHelpers.ts
@@ -14,14 +14,10 @@ export const toWebPreset = (preset: Preset): Preset => {
   const webPreset = { ...preset };
 
   (Object.keys(preset) as Array<keyof Preset>).map((style) => {
-    if (
-      style === 'fontSize' ||
-      style === 'lineHeight' ||
-      style === 'letterSpacing'
-    ) {
+    if (style === 'lineHeight') {
       return (webPreset[style] = toPx(preset[style]));
     } else {
-      return (webPreset[style] = preset[style]);
+      return (webPreset[style] = preset[style] as string);
     }
   });
 

--- a/helpers/webOnlyHelpers.ts
+++ b/helpers/webOnlyHelpers.ts
@@ -1,4 +1,4 @@
-const toPx = (value: number | string): string => {
+const toPx = (value: number): string => {
   return `${value}px`;
 };
 

--- a/helpers/webOnlyHelpers.ts
+++ b/helpers/webOnlyHelpers.ts
@@ -1,4 +1,6 @@
-const toPx = (value: number): string => {
+import { type Preset } from '../token-presets';
+
+const toPx = (value: number | string): string => {
   return `${value}px`;
 };
 
@@ -8,10 +10,10 @@ export const toWebToken = (token: number): string => {
 };
 
 // Essa função foi criada para resolver o uso dos presets em casos web-only
-export const toWebPreset = (preset: any): any => {
-  const webPreset = {};
+export const toWebPreset = (preset: Preset): Preset => {
+  const webPreset = { ...preset };
 
-  Object.keys(preset).map((style) => {
+  (Object.keys(preset) as Array<keyof Preset>).map((style) => {
     if (
       style === 'fontSize' ||
       style === 'lineHeight' ||

--- a/helpers/webOnlyHelpers.ts
+++ b/helpers/webOnlyHelpers.ts
@@ -1,5 +1,3 @@
-import { type Preset } from '../token-presets';
-
 const toPx = (value: number | string): string => {
   return `${value}px`;
 };
@@ -10,6 +8,8 @@ export const toWebToken = (token: number): string => {
 };
 
 // Essa função foi criada para resolver o uso dos presets em casos web-only
-export const toWebPreset = (preset: Preset): Preset => {
+export const toWebPreset = <Preset extends { lineHeight: number }>(
+  preset: Preset
+): Preset & { lineHeight: string } => {
   return { ...preset, lineHeight: toPx(preset.lineHeight) };
 };

--- a/helpers/webOnlyHelpers.ts
+++ b/helpers/webOnlyHelpers.ts
@@ -6,3 +6,22 @@ const toPx = (value: number): string => {
 export const toWebToken = (token: number): string => {
   return toPx(token);
 };
+
+// Essa função foi criada para resolver o uso dos presets em casos web-only
+export const toWebPreset = (preset: any): any => {
+  const webPreset = {};
+
+  Object.keys(preset).map((style) => {
+    if (
+      style === 'fontSize' ||
+      style === 'lineHeight' ||
+      style === 'letterSpacing'
+    ) {
+      return (webPreset[style] = toPx(preset[style]));
+    } else {
+      return (webPreset[style] = preset[style]);
+    }
+  });
+
+  return webPreset;
+};

--- a/stories/presets/typography/basic.stories.mdx
+++ b/stories/presets/typography/basic.stories.mdx
@@ -27,112 +27,64 @@ import {
 
 # Headings
 
-<PresetsDocBlock 
-  name="H1" 
-  preset={DSA_BASIC_HEADING_H1_STYLE}
-/>
+<PresetsDocBlock name="H1" preset={DSA_BASIC_HEADING_H1_STYLE} />
 
-<PresetsDocBlock 
-  name="H2" 
-  preset={DSA_BASIC_HEADING_H2_STYLE}
-/>
+<PresetsDocBlock name="H2" preset={DSA_BASIC_HEADING_H2_STYLE} />
 
-<PresetsDocBlock 
-  name="H3" 
-  preset={DSA_BASIC_HEADING_H3_STYLE}
-/>
+<PresetsDocBlock name="H3" preset={DSA_BASIC_HEADING_H3_STYLE} />
 
 # Body (large)
 
-<PresetsDocBlock 
-  name="Normal" 
-  preset={DSA_BASIC_BODY_L_NORMAL_STYLE}
-/>
+<PresetsDocBlock name="Normal" preset={DSA_BASIC_BODY_L_NORMAL_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold" 
-  preset={DSA_BASIC_BODY_L_BOLD_STYLE}
-/>
+<PresetsDocBlock name="Bold" preset={DSA_BASIC_BODY_L_BOLD_STYLE} />
 
-<PresetsDocBlock 
-  name="Italic" 
-  preset={DSA_BASIC_BODY_L_ITALIC_STYLE}
-/>
+<PresetsDocBlock name="Italic" preset={DSA_BASIC_BODY_L_ITALIC_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold & Italic" 
+<PresetsDocBlock
+  name="Bold & Italic"
   preset={DSA_BASIC_BODY_L_BOLDITALIC_STYLE}
 />
 
 # Body (medium)
 
-<PresetsDocBlock 
-  name="Normal" 
-  preset={DSA_BASIC_BODY_M_NORMAL_STYLE}
-/>
+<PresetsDocBlock name="Normal" preset={DSA_BASIC_BODY_M_NORMAL_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold" 
-  preset={DSA_BASIC_BODY_M_BOLD_STYLE}
-/>
+<PresetsDocBlock name="Bold" preset={DSA_BASIC_BODY_M_BOLD_STYLE} />
 
-<PresetsDocBlock 
-  name="Italic" 
-  preset={DSA_BASIC_BODY_M_ITALIC_STYLE}
-/>
+<PresetsDocBlock name="Italic" preset={DSA_BASIC_BODY_M_ITALIC_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold & Italic" 
+<PresetsDocBlock
+  name="Bold & Italic"
   preset={DSA_BASIC_BODY_M_BOLDITALIC_STYLE}
 />
 
 # Body (small)
 
-<PresetsDocBlock 
-  name="Normal" 
-  preset={DSA_BASIC_BODY_S_NORMAL_STYLE}
-/>
+<PresetsDocBlock name="Normal" preset={DSA_BASIC_BODY_S_NORMAL_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold" 
-  preset={DSA_BASIC_BODY_S_BOLD_STYLE}
-/>
+<PresetsDocBlock name="Bold" preset={DSA_BASIC_BODY_S_BOLD_STYLE} />
 
-<PresetsDocBlock 
-  name="Italic" 
-  preset={DSA_BASIC_BODY_S_ITALIC_STYLE}
-/>
+<PresetsDocBlock name="Italic" preset={DSA_BASIC_BODY_S_ITALIC_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold & Italic" 
+<PresetsDocBlock
+  name="Bold & Italic"
   preset={DSA_BASIC_BODY_S_BOLDITALIC_STYLE}
 />
 
 # Body (extra small)
 
-<PresetsDocBlock 
-  name="Normal" 
-  preset={DSA_BASIC_BODY_XS_NORMAL_STYLE}
-/>
+<PresetsDocBlock name="Normal" preset={DSA_BASIC_BODY_XS_NORMAL_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold" 
-  preset={DSA_BASIC_BODY_XS_BOLD_STYLE}
-/>
+<PresetsDocBlock name="Bold" preset={DSA_BASIC_BODY_XS_BOLD_STYLE} />
 
-<PresetsDocBlock 
-  name="Italic" 
-  preset={DSA_BASIC_BODY_XS_ITALIC_STYLE}
-/>
+<PresetsDocBlock name="Italic" preset={DSA_BASIC_BODY_XS_ITALIC_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold & Italic" 
+<PresetsDocBlock
+  name="Bold & Italic"
   preset={DSA_BASIC_BODY_XS_BOLDITALIC_STYLE}
 />
 
 # Body (extra extra small)
 
-<PresetsDocBlock 
-  name="Normal" 
-  preset={DSA_BASIC_BODY_XXS_NORMAL_STYLE}
-/>
+<PresetsDocBlock name="Normal" preset={DSA_BASIC_BODY_XXS_NORMAL_STYLE} />

--- a/stories/presets/typography/basic.stories.mdx
+++ b/stories/presets/typography/basic.stories.mdx
@@ -1,0 +1,138 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
+import PresetsDocBlock from '../../../utils/PresetsDocBlock';
+import {
+  DSA_BASIC_HEADING_H1_STYLE,
+  DSA_BASIC_HEADING_H2_STYLE,
+  DSA_BASIC_HEADING_H3_STYLE,
+  DSA_BASIC_BODY_L_NORMAL_STYLE,
+  DSA_BASIC_BODY_L_BOLD_STYLE,
+  DSA_BASIC_BODY_L_ITALIC_STYLE,
+  DSA_BASIC_BODY_L_BOLDITALIC_STYLE,
+  DSA_BASIC_BODY_M_NORMAL_STYLE,
+  DSA_BASIC_BODY_M_BOLD_STYLE,
+  DSA_BASIC_BODY_M_ITALIC_STYLE,
+  DSA_BASIC_BODY_M_BOLDITALIC_STYLE,
+  DSA_BASIC_BODY_S_NORMAL_STYLE,
+  DSA_BASIC_BODY_S_BOLD_STYLE,
+  DSA_BASIC_BODY_S_ITALIC_STYLE,
+  DSA_BASIC_BODY_S_BOLDITALIC_STYLE,
+  DSA_BASIC_BODY_XS_NORMAL_STYLE,
+  DSA_BASIC_BODY_XS_BOLD_STYLE,
+  DSA_BASIC_BODY_XS_ITALIC_STYLE,
+  DSA_BASIC_BODY_XS_BOLDITALIC_STYLE,
+  DSA_BASIC_BODY_XXS_NORMAL_STYLE,
+} from '../../../token-presets';
+
+<Meta title="Design Tokens/Tipografia/Presets/Basic" />
+
+# Headings
+
+<PresetsDocBlock 
+  name="H1" 
+  preset={DSA_BASIC_HEADING_H1_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="H2" 
+  preset={DSA_BASIC_HEADING_H2_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="H3" 
+  preset={DSA_BASIC_HEADING_H3_STYLE}
+/>
+
+# Body (large)
+
+<PresetsDocBlock 
+  name="Normal" 
+  preset={DSA_BASIC_BODY_L_NORMAL_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold" 
+  preset={DSA_BASIC_BODY_L_BOLD_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Italic" 
+  preset={DSA_BASIC_BODY_L_ITALIC_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold & Italic" 
+  preset={DSA_BASIC_BODY_L_BOLDITALIC_STYLE}
+/>
+
+# Body (medium)
+
+<PresetsDocBlock 
+  name="Normal" 
+  preset={DSA_BASIC_BODY_M_NORMAL_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold" 
+  preset={DSA_BASIC_BODY_M_BOLD_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Italic" 
+  preset={DSA_BASIC_BODY_M_ITALIC_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold & Italic" 
+  preset={DSA_BASIC_BODY_M_BOLDITALIC_STYLE}
+/>
+
+# Body (small)
+
+<PresetsDocBlock 
+  name="Normal" 
+  preset={DSA_BASIC_BODY_S_NORMAL_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold" 
+  preset={DSA_BASIC_BODY_S_BOLD_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Italic" 
+  preset={DSA_BASIC_BODY_S_ITALIC_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold & Italic" 
+  preset={DSA_BASIC_BODY_S_BOLDITALIC_STYLE}
+/>
+
+# Body (extra small)
+
+<PresetsDocBlock 
+  name="Normal" 
+  preset={DSA_BASIC_BODY_XS_NORMAL_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold" 
+  preset={DSA_BASIC_BODY_XS_BOLD_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Italic" 
+  preset={DSA_BASIC_BODY_XS_ITALIC_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold & Italic" 
+  preset={DSA_BASIC_BODY_XS_BOLDITALIC_STYLE}
+/>
+
+# Body (extra extra small)
+
+<PresetsDocBlock 
+  name="Normal" 
+  preset={DSA_BASIC_BODY_XXS_NORMAL_STYLE}
+/>

--- a/stories/presets/typography/ludic.stories.mdx
+++ b/stories/presets/typography/ludic.stories.mdx
@@ -1,0 +1,138 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
+import PresetsDocBlock from '../../../utils/PresetsDocBlock';
+import {
+  DSA_LUDIC_HEADING_H1_STYLE,
+  DSA_LUDIC_HEADING_H2_STYLE,
+  DSA_LUDIC_HEADING_H3_STYLE,
+  DSA_LUDIC_BODY_L_NORMAL_STYLE,
+  DSA_LUDIC_BODY_L_BOLD_STYLE,
+  DSA_LUDIC_BODY_L_ITALIC_STYLE,
+  DSA_LUDIC_BODY_L_BOLDITALIC_STYLE,
+  DSA_LUDIC_BODY_M_NORMAL_STYLE,
+  DSA_LUDIC_BODY_M_BOLD_STYLE,
+  DSA_LUDIC_BODY_M_ITALIC_STYLE,
+  DSA_LUDIC_BODY_M_BOLDITALIC_STYLE,
+  DSA_LUDIC_BODY_S_NORMAL_STYLE,
+  DSA_LUDIC_BODY_S_BOLD_STYLE,
+  DSA_LUDIC_BODY_S_ITALIC_STYLE,
+  DSA_LUDIC_BODY_S_BOLDITALIC_STYLE,
+  DSA_LUDIC_BODY_XS_NORMAL_STYLE,
+  DSA_LUDIC_BODY_XS_BOLD_STYLE,
+  DSA_LUDIC_BODY_XS_ITALIC_STYLE,
+  DSA_LUDIC_BODY_XS_BOLDITALIC_STYLE,
+  DSA_LUDIC_BODY_XXS_NORMAL_STYLE,
+} from '../../../token-presets';
+
+<Meta title="Design Tokens/Tipografia/Presets/Ludic" />
+
+# Headings
+
+<PresetsDocBlock 
+  name="H1" 
+  preset={DSA_LUDIC_HEADING_H1_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="H2" 
+  preset={DSA_LUDIC_HEADING_H2_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="H3" 
+  preset={DSA_LUDIC_HEADING_H3_STYLE}
+/>
+
+# Body (large)
+
+<PresetsDocBlock 
+  name="Normal" 
+  preset={DSA_LUDIC_BODY_L_NORMAL_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold" 
+  preset={DSA_LUDIC_BODY_L_BOLD_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Italic" 
+  preset={DSA_LUDIC_BODY_L_ITALIC_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold & Italic" 
+  preset={DSA_LUDIC_BODY_L_BOLDITALIC_STYLE}
+/>
+
+# Body (medium)
+
+<PresetsDocBlock 
+  name="Normal" 
+  preset={DSA_LUDIC_BODY_M_NORMAL_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold" 
+  preset={DSA_LUDIC_BODY_M_BOLD_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Italic" 
+  preset={DSA_LUDIC_BODY_M_ITALIC_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold & Italic" 
+  preset={DSA_LUDIC_BODY_M_BOLDITALIC_STYLE}
+/>
+
+# Body (small)
+
+<PresetsDocBlock 
+  name="Normal" 
+  preset={DSA_LUDIC_BODY_S_NORMAL_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold" 
+  preset={DSA_LUDIC_BODY_S_BOLD_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Italic" 
+  preset={DSA_LUDIC_BODY_S_ITALIC_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold & Italic" 
+  preset={DSA_LUDIC_BODY_S_BOLDITALIC_STYLE}
+/>
+
+# Body (extra small)
+
+<PresetsDocBlock 
+  name="Normal" 
+  preset={DSA_LUDIC_BODY_XS_NORMAL_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold" 
+  preset={DSA_LUDIC_BODY_XS_BOLD_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Italic" 
+  preset={DSA_LUDIC_BODY_XS_ITALIC_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold & Italic" 
+  preset={DSA_LUDIC_BODY_XS_BOLDITALIC_STYLE}
+/>
+
+# Body (extra extra small)
+
+<PresetsDocBlock 
+  name="Normal" 
+  preset={DSA_LUDIC_BODY_XXS_NORMAL_STYLE}
+/>

--- a/stories/presets/typography/ludic.stories.mdx
+++ b/stories/presets/typography/ludic.stories.mdx
@@ -27,112 +27,64 @@ import {
 
 # Headings
 
-<PresetsDocBlock 
-  name="H1" 
-  preset={DSA_LUDIC_HEADING_H1_STYLE}
-/>
+<PresetsDocBlock name="H1" preset={DSA_LUDIC_HEADING_H1_STYLE} />
 
-<PresetsDocBlock 
-  name="H2" 
-  preset={DSA_LUDIC_HEADING_H2_STYLE}
-/>
+<PresetsDocBlock name="H2" preset={DSA_LUDIC_HEADING_H2_STYLE} />
 
-<PresetsDocBlock 
-  name="H3" 
-  preset={DSA_LUDIC_HEADING_H3_STYLE}
-/>
+<PresetsDocBlock name="H3" preset={DSA_LUDIC_HEADING_H3_STYLE} />
 
 # Body (large)
 
-<PresetsDocBlock 
-  name="Normal" 
-  preset={DSA_LUDIC_BODY_L_NORMAL_STYLE}
-/>
+<PresetsDocBlock name="Normal" preset={DSA_LUDIC_BODY_L_NORMAL_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold" 
-  preset={DSA_LUDIC_BODY_L_BOLD_STYLE}
-/>
+<PresetsDocBlock name="Bold" preset={DSA_LUDIC_BODY_L_BOLD_STYLE} />
 
-<PresetsDocBlock 
-  name="Italic" 
-  preset={DSA_LUDIC_BODY_L_ITALIC_STYLE}
-/>
+<PresetsDocBlock name="Italic" preset={DSA_LUDIC_BODY_L_ITALIC_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold & Italic" 
+<PresetsDocBlock
+  name="Bold & Italic"
   preset={DSA_LUDIC_BODY_L_BOLDITALIC_STYLE}
 />
 
 # Body (medium)
 
-<PresetsDocBlock 
-  name="Normal" 
-  preset={DSA_LUDIC_BODY_M_NORMAL_STYLE}
-/>
+<PresetsDocBlock name="Normal" preset={DSA_LUDIC_BODY_M_NORMAL_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold" 
-  preset={DSA_LUDIC_BODY_M_BOLD_STYLE}
-/>
+<PresetsDocBlock name="Bold" preset={DSA_LUDIC_BODY_M_BOLD_STYLE} />
 
-<PresetsDocBlock 
-  name="Italic" 
-  preset={DSA_LUDIC_BODY_M_ITALIC_STYLE}
-/>
+<PresetsDocBlock name="Italic" preset={DSA_LUDIC_BODY_M_ITALIC_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold & Italic" 
+<PresetsDocBlock
+  name="Bold & Italic"
   preset={DSA_LUDIC_BODY_M_BOLDITALIC_STYLE}
 />
 
 # Body (small)
 
-<PresetsDocBlock 
-  name="Normal" 
-  preset={DSA_LUDIC_BODY_S_NORMAL_STYLE}
-/>
+<PresetsDocBlock name="Normal" preset={DSA_LUDIC_BODY_S_NORMAL_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold" 
-  preset={DSA_LUDIC_BODY_S_BOLD_STYLE}
-/>
+<PresetsDocBlock name="Bold" preset={DSA_LUDIC_BODY_S_BOLD_STYLE} />
 
-<PresetsDocBlock 
-  name="Italic" 
-  preset={DSA_LUDIC_BODY_S_ITALIC_STYLE}
-/>
+<PresetsDocBlock name="Italic" preset={DSA_LUDIC_BODY_S_ITALIC_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold & Italic" 
+<PresetsDocBlock
+  name="Bold & Italic"
   preset={DSA_LUDIC_BODY_S_BOLDITALIC_STYLE}
 />
 
 # Body (extra small)
 
-<PresetsDocBlock 
-  name="Normal" 
-  preset={DSA_LUDIC_BODY_XS_NORMAL_STYLE}
-/>
+<PresetsDocBlock name="Normal" preset={DSA_LUDIC_BODY_XS_NORMAL_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold" 
-  preset={DSA_LUDIC_BODY_XS_BOLD_STYLE}
-/>
+<PresetsDocBlock name="Bold" preset={DSA_LUDIC_BODY_XS_BOLD_STYLE} />
 
-<PresetsDocBlock 
-  name="Italic" 
-  preset={DSA_LUDIC_BODY_XS_ITALIC_STYLE}
-/>
+<PresetsDocBlock name="Italic" preset={DSA_LUDIC_BODY_XS_ITALIC_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold & Italic" 
+<PresetsDocBlock
+  name="Bold & Italic"
   preset={DSA_LUDIC_BODY_XS_BOLDITALIC_STYLE}
 />
 
 # Body (extra extra small)
 
-<PresetsDocBlock 
-  name="Normal" 
-  preset={DSA_LUDIC_BODY_XXS_NORMAL_STYLE}
-/>
+<PresetsDocBlock name="Normal" preset={DSA_LUDIC_BODY_XXS_NORMAL_STYLE} />

--- a/stories/presets/typography/reading.stories.mdx
+++ b/stories/presets/typography/reading.stories.mdx
@@ -23,88 +23,52 @@ import {
 
 # Body (large)
 
-<PresetsDocBlock 
-  name="Normal" 
-  preset={DSA_READING_BODY_L_NORMAL_STYLE}
-/>
+<PresetsDocBlock name="Normal" preset={DSA_READING_BODY_L_NORMAL_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold" 
-  preset={DSA_READING_BODY_L_BOLD_STYLE}
-/>
+<PresetsDocBlock name="Bold" preset={DSA_READING_BODY_L_BOLD_STYLE} />
 
-<PresetsDocBlock 
-  name="Italic" 
-  preset={DSA_READING_BODY_L_ITALIC_STYLE}
-/>
+<PresetsDocBlock name="Italic" preset={DSA_READING_BODY_L_ITALIC_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold & Italic" 
+<PresetsDocBlock
+  name="Bold & Italic"
   preset={DSA_READING_BODY_L_BOLDITALIC_STYLE}
 />
 
 # Body (medium)
 
-<PresetsDocBlock 
-  name="Normal" 
-  preset={DSA_READING_BODY_M_NORMAL_STYLE}
-/>
+<PresetsDocBlock name="Normal" preset={DSA_READING_BODY_M_NORMAL_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold" 
-  preset={DSA_READING_BODY_M_BOLD_STYLE}
-/>
+<PresetsDocBlock name="Bold" preset={DSA_READING_BODY_M_BOLD_STYLE} />
 
-<PresetsDocBlock 
-  name="Italic" 
-  preset={DSA_READING_BODY_M_ITALIC_STYLE}
-/>
+<PresetsDocBlock name="Italic" preset={DSA_READING_BODY_M_ITALIC_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold & Italic" 
+<PresetsDocBlock
+  name="Bold & Italic"
   preset={DSA_READING_BODY_M_BOLDITALIC_STYLE}
 />
 
 # Body (small)
 
-<PresetsDocBlock 
-  name="Normal" 
-  preset={DSA_READING_BODY_S_NORMAL_STYLE}
-/>
+<PresetsDocBlock name="Normal" preset={DSA_READING_BODY_S_NORMAL_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold" 
-  preset={DSA_READING_BODY_S_BOLD_STYLE}
-/>
+<PresetsDocBlock name="Bold" preset={DSA_READING_BODY_S_BOLD_STYLE} />
 
-<PresetsDocBlock 
-  name="Italic" 
-  preset={DSA_READING_BODY_S_ITALIC_STYLE}
-/>
+<PresetsDocBlock name="Italic" preset={DSA_READING_BODY_S_ITALIC_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold & Italic" 
+<PresetsDocBlock
+  name="Bold & Italic"
   preset={DSA_READING_BODY_S_BOLDITALIC_STYLE}
 />
 
 # Body (extra small)
 
-<PresetsDocBlock 
-  name="Normal" 
-  preset={DSA_READING_BODY_XS_NORMAL_STYLE}
-/>
+<PresetsDocBlock name="Normal" preset={DSA_READING_BODY_XS_NORMAL_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold" 
-  preset={DSA_READING_BODY_XS_BOLD_STYLE}
-/>
+<PresetsDocBlock name="Bold" preset={DSA_READING_BODY_XS_BOLD_STYLE} />
 
-<PresetsDocBlock 
-  name="Italic" 
-  preset={DSA_READING_BODY_XS_ITALIC_STYLE}
-/>
+<PresetsDocBlock name="Italic" preset={DSA_READING_BODY_XS_ITALIC_STYLE} />
 
-<PresetsDocBlock 
-  name="Bold & Italic" 
+<PresetsDocBlock
+  name="Bold & Italic"
   preset={DSA_READING_BODY_XS_BOLDITALIC_STYLE}
 />

--- a/stories/presets/typography/reading.stories.mdx
+++ b/stories/presets/typography/reading.stories.mdx
@@ -1,0 +1,110 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs';
+import PresetsDocBlock from '../../../utils/PresetsDocBlock';
+import {
+  DSA_READING_BODY_L_NORMAL_STYLE,
+  DSA_READING_BODY_L_BOLD_STYLE,
+  DSA_READING_BODY_L_ITALIC_STYLE,
+  DSA_READING_BODY_L_BOLDITALIC_STYLE,
+  DSA_READING_BODY_M_NORMAL_STYLE,
+  DSA_READING_BODY_M_BOLD_STYLE,
+  DSA_READING_BODY_M_ITALIC_STYLE,
+  DSA_READING_BODY_M_BOLDITALIC_STYLE,
+  DSA_READING_BODY_S_NORMAL_STYLE,
+  DSA_READING_BODY_S_BOLD_STYLE,
+  DSA_READING_BODY_S_ITALIC_STYLE,
+  DSA_READING_BODY_S_BOLDITALIC_STYLE,
+  DSA_READING_BODY_XS_NORMAL_STYLE,
+  DSA_READING_BODY_XS_BOLD_STYLE,
+  DSA_READING_BODY_XS_ITALIC_STYLE,
+  DSA_READING_BODY_XS_BOLDITALIC_STYLE,
+} from '../../../token-presets';
+
+<Meta title="Design Tokens/Tipografia/Presets/Reading" />
+
+# Body (large)
+
+<PresetsDocBlock 
+  name="Normal" 
+  preset={DSA_READING_BODY_L_NORMAL_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold" 
+  preset={DSA_READING_BODY_L_BOLD_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Italic" 
+  preset={DSA_READING_BODY_L_ITALIC_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold & Italic" 
+  preset={DSA_READING_BODY_L_BOLDITALIC_STYLE}
+/>
+
+# Body (medium)
+
+<PresetsDocBlock 
+  name="Normal" 
+  preset={DSA_READING_BODY_M_NORMAL_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold" 
+  preset={DSA_READING_BODY_M_BOLD_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Italic" 
+  preset={DSA_READING_BODY_M_ITALIC_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold & Italic" 
+  preset={DSA_READING_BODY_M_BOLDITALIC_STYLE}
+/>
+
+# Body (small)
+
+<PresetsDocBlock 
+  name="Normal" 
+  preset={DSA_READING_BODY_S_NORMAL_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold" 
+  preset={DSA_READING_BODY_S_BOLD_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Italic" 
+  preset={DSA_READING_BODY_S_ITALIC_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold & Italic" 
+  preset={DSA_READING_BODY_S_BOLDITALIC_STYLE}
+/>
+
+# Body (extra small)
+
+<PresetsDocBlock 
+  name="Normal" 
+  preset={DSA_READING_BODY_XS_NORMAL_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold" 
+  preset={DSA_READING_BODY_XS_BOLD_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Italic" 
+  preset={DSA_READING_BODY_XS_ITALIC_STYLE}
+/>
+
+<PresetsDocBlock 
+  name="Bold & Italic" 
+  preset={DSA_READING_BODY_XS_BOLDITALIC_STYLE}
+/>

--- a/stories/tokens/typographyTokens.stories.mdx
+++ b/stories/tokens/typographyTokens.stories.mdx
@@ -4,7 +4,7 @@ import CustomDesignTokenDocBlock from '../../utils/CustomDesignTokenDocBlock';
 
 import typograpyTokens from '../../tokens/src/typography.json';
 
-<Meta title="Design Tokens/Tipografia" />
+<Meta title="Design Tokens/Tipografia/Tokens" />
 
 # Tipografia
 

--- a/token-presets/index.ts
+++ b/token-presets/index.ts
@@ -1,3 +1,11 @@
 export * from './basic';
 export * from './ludic';
 export * from './reading';
+
+export interface Preset {
+  fontFamily: string;
+  fontSize: number | string;
+  fontWeight: string;
+  letterSpacing: number | string;
+  lineHeight: number | string;
+}

--- a/token-presets/index.ts
+++ b/token-presets/index.ts
@@ -1,11 +1,3 @@
 export * from './basic';
 export * from './ludic';
 export * from './reading';
-
-export interface Preset {
-  fontFamily: string;
-  fontSize: number | string;
-  fontWeight: string;
-  letterSpacing: number | string;
-  lineHeight: number | string;
-}

--- a/utils/PresetsDocBlock/index.tsx
+++ b/utils/PresetsDocBlock/index.tsx
@@ -4,14 +4,13 @@ import * as tokens from '../../built-tokens/js/tokens';
 import * as presets from '../../token-presets';
 
 import { toWebPreset } from '../../helpers/webOnlyHelpers';
+import { type Preset } from '../../token-presets';
 
-interface Preset {
-  fontFamily: string;
-  fontSize: number;
-  fontWeight: string;
-  letterSpacing: number;
-  lineHeight: number;
-}
+const allPresets = { ...presets };
+const allTokens = { ...tokens };
+
+type PresetKeys = keyof typeof allPresets;
+type TokensKeys = keyof typeof allTokens;
 
 interface PresetsDocBlockProps {
   name: string;
@@ -26,8 +25,8 @@ const PresetsDocBlock: React.FC<PresetsDocBlockProps> = (props) => {
       <div className="name">
         {name}
         <div className="token-name">
-          {Object.keys(presets).map((key) => {
-            if (presets[key] === preset) return key;
+          {(Object.keys(allPresets) as PresetKeys[]).map((key) => {
+            if (allPresets[key] === preset) return key;
             return null;
           })}
         </div>
@@ -38,9 +37,9 @@ const PresetsDocBlock: React.FC<PresetsDocBlockProps> = (props) => {
             <div className="token" key={key}>
               <div className="key">{key}:</div>
               <div className="value">
-                {Object.keys(tokens).map((tokenKey) => {
+                {(Object.keys(tokens) as TokensKeys[]).map((tokenKey) => {
                   if (
-                    tokens[tokenKey] === preset[key] &&
+                    tokens[tokenKey] === preset[key as keyof typeof preset] &&
                     tokenKey
                       .toLowerCase()
                       .replace(/_/g, '')

--- a/utils/PresetsDocBlock/index.tsx
+++ b/utils/PresetsDocBlock/index.tsx
@@ -35,9 +35,10 @@ const PresetsDocBlock: React.FC<PresetsDocBlockProps> = (props) => {
             <div className="token" key={key}>
               <div className="key">{key}:</div>
               <div className="value">
-                {(Object.keys(tokens)).map((tokenKey) => {
+                {Object.keys(tokens).map((tokenKey) => {
                   if (
-                    tokens[tokenKey as keyof typeof tokens] === preset[key as keyof typeof preset] &&
+                    tokens[tokenKey as keyof typeof tokens] ===
+                      preset[key as keyof typeof preset] &&
                     tokenKey
                       .toLowerCase()
                       .replace(/_/g, '')

--- a/utils/PresetsDocBlock/index.tsx
+++ b/utils/PresetsDocBlock/index.tsx
@@ -7,7 +7,7 @@ import { toWebPreset } from '../../helpers/webOnlyHelpers';
 
 const allPresets = { ...presets };
 
-type PresetNames = keyof typeof allPresets;
+type PresetName = keyof typeof allPresets;
 
 interface Preset {
   fontFamily: string;
@@ -30,7 +30,7 @@ const PresetsDocBlock: React.FC<PresetsDocBlockProps> = (props) => {
       <div className="name">
         {name}
         <div className="token-name">
-          {(Object.keys(allPresets) as PresetNames[]).map((presetName) => {
+          {(Object.keys(allPresets) as PresetName[]).map((presetName) => {
             if (allPresets[presetName] === preset) return presetName;
             return null;
           })}

--- a/utils/PresetsDocBlock/index.tsx
+++ b/utils/PresetsDocBlock/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import './styles.css';
-import * as tokens from '../../build/tokens/ts/tokens';
+import * as tokens from '../../built-tokens/js/tokens';
 import * as presets from '../../token-presets';
 
 import { toWebPreset } from '../../helpers/webOnlyHelpers';

--- a/utils/PresetsDocBlock/index.tsx
+++ b/utils/PresetsDocBlock/index.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import './styles.css';
+import * as tokens from '../../build/tokens/ts/tokens';
+import * as presets from '../../token-presets';
+
+import { toWebPreset } from '../../helpers/webOnlyHelpers';
+
+interface PresetsDocBlockProps {
+  name: string;
+  preset: any;
+}
+
+const PresetsDocBlock: React.FC<PresetsDocBlockProps> = (props) => {
+  const { name, preset } = props;
+
+  return (
+    <div className="presets-container">
+      <div className="name">
+        {name}
+        <div className="token-name">
+          {Object.keys(presets).map((key) => {
+            if (presets[key] === preset) return key;
+            return null;
+          })}
+        </div>
+      </div>
+      <div className="tokens">
+        {Object.keys(preset).map((key) => {
+          return (
+            // eslint-disable-next-line react/jsx-key
+            <div className="token">
+              <div className="key">{key}:</div>
+              <div className="value">
+                {Object.keys(tokens).map((tokenKey) => {
+                  if (
+                    tokens[tokenKey] === preset[key] &&
+                    tokenKey
+                      .toLowerCase()
+                      .replace(/_/g, '')
+                      .includes(key.toLowerCase())
+                  ) {
+                    return tokenKey;
+                  }
+                  return null;
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <div className="preview" style={toWebPreset(preset)}>
+        almost before we knew it, we had left the ground.
+      </div>
+    </div>
+  );
+};
+
+export default PresetsDocBlock;

--- a/utils/PresetsDocBlock/index.tsx
+++ b/utils/PresetsDocBlock/index.tsx
@@ -4,11 +4,18 @@ import * as tokens from '../../built-tokens/js/tokens';
 import * as presets from '../../token-presets';
 
 import { toWebPreset } from '../../helpers/webOnlyHelpers';
-import { type Preset } from '../../token-presets';
 
 const allPresets = { ...presets };
 
 type PresetNames = keyof typeof allPresets;
+
+interface Preset {
+  fontFamily: string;
+  fontSize: number;
+  fontWeight: string;
+  letterSpacing: number;
+  lineHeight: number;
+}
 
 interface PresetsDocBlockProps {
   name: string;
@@ -23,35 +30,38 @@ const PresetsDocBlock: React.FC<PresetsDocBlockProps> = (props) => {
       <div className="name">
         {name}
         <div className="token-name">
-          {(Object.keys(allPresets) as PresetNames[]).map((key) => {
-            if (allPresets[key] === preset) return key;
+          {(Object.keys(allPresets) as PresetNames[]).map((presetName) => {
+            if (allPresets[presetName] === preset) return presetName;
             return null;
           })}
         </div>
       </div>
       <div className="tokens">
-        {(Object.keys(preset) as PresetNames[]).map((key) => {
-          return (
-            <div className="token" key={key}>
-              <div className="key">{key}:</div>
-              <div className="value">
-                {Object.keys(tokens).map((tokenKey) => {
-                  if (
-                    tokens[tokenKey as keyof typeof tokens] ===
-                      preset[key as keyof typeof preset] &&
-                    tokenKey
-                      .toLowerCase()
-                      .replace(/_/g, '')
-                      .includes(key.toLowerCase())
-                  ) {
-                    return tokenKey;
-                  }
-                  return null;
-                })}
+        {(Object.keys(preset) as Array<keyof typeof preset>).map(
+          (presetStyle) => {
+            return (
+              <div className="token" key={presetStyle}>
+                <div className="key">{presetStyle}:</div>
+                <div className="value">
+                  {(Object.keys(tokens) as Array<keyof typeof tokens>).map(
+                    (tokenName) => {
+                      if (
+                        tokens[tokenName] === preset[presetStyle] &&
+                        tokenName
+                          .toLowerCase()
+                          .replace(/_/g, '')
+                          .includes(presetStyle.toLowerCase())
+                      ) {
+                        return tokenName;
+                      }
+                      return null;
+                    }
+                  )}
+                </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          }
+        )}
       </div>
       <div className="preview" style={toWebPreset(preset)}>
         almost before we knew it, we had left the ground.

--- a/utils/PresetsDocBlock/index.tsx
+++ b/utils/PresetsDocBlock/index.tsx
@@ -5,9 +5,17 @@ import * as presets from '../../token-presets';
 
 import { toWebPreset } from '../../helpers/webOnlyHelpers';
 
+interface Preset {
+  fontFamily: string;
+  fontSize: number;
+  fontWeight: string;
+  letterSpacing: number;
+  lineHeight: number;
+}
+
 interface PresetsDocBlockProps {
   name: string;
-  preset: any;
+  preset: Preset;
 }
 
 const PresetsDocBlock: React.FC<PresetsDocBlockProps> = (props) => {
@@ -27,8 +35,7 @@ const PresetsDocBlock: React.FC<PresetsDocBlockProps> = (props) => {
       <div className="tokens">
         {Object.keys(preset).map((key) => {
           return (
-            // eslint-disable-next-line react/jsx-key
-            <div className="token">
+            <div className="token" key={key}>
               <div className="key">{key}:</div>
               <div className="value">
                 {Object.keys(tokens).map((tokenKey) => {

--- a/utils/PresetsDocBlock/index.tsx
+++ b/utils/PresetsDocBlock/index.tsx
@@ -7,10 +7,8 @@ import { toWebPreset } from '../../helpers/webOnlyHelpers';
 import { type Preset } from '../../token-presets';
 
 const allPresets = { ...presets };
-const allTokens = { ...tokens };
 
-type PresetKeys = keyof typeof allPresets;
-type TokensKeys = keyof typeof allTokens;
+type PresetNames = keyof typeof allPresets;
 
 interface PresetsDocBlockProps {
   name: string;
@@ -25,21 +23,21 @@ const PresetsDocBlock: React.FC<PresetsDocBlockProps> = (props) => {
       <div className="name">
         {name}
         <div className="token-name">
-          {(Object.keys(allPresets) as PresetKeys[]).map((key) => {
+          {(Object.keys(allPresets) as PresetNames[]).map((key) => {
             if (allPresets[key] === preset) return key;
             return null;
           })}
         </div>
       </div>
       <div className="tokens">
-        {Object.keys(preset).map((key) => {
+        {(Object.keys(preset) as PresetNames[]).map((key) => {
           return (
             <div className="token" key={key}>
               <div className="key">{key}:</div>
               <div className="value">
-                {(Object.keys(tokens) as TokensKeys[]).map((tokenKey) => {
+                {(Object.keys(tokens)).map((tokenKey) => {
                   if (
-                    tokens[tokenKey] === preset[key as keyof typeof preset] &&
+                    tokens[tokenKey as keyof typeof tokens] === preset[key as keyof typeof preset] &&
                     tokenKey
                       .toLowerCase()
                       .replace(/_/g, '')

--- a/utils/PresetsDocBlock/styles.css
+++ b/utils/PresetsDocBlock/styles.css
@@ -23,7 +23,7 @@
 
 .token-name {
   padding-top: 12px;
-  color: #F0F;
+  color: #f0f;
   font-family: 'Lato' !important;
   font-size: 13px !important;
   font-style: normal;
@@ -61,7 +61,7 @@
 }
 
 .tokens .token .value {
-  color: #F0F;
+  color: #f0f;
   font-feature-settings: 'clig' off, 'liga' off;
   font-family: 'Lato' !important;
   font-size: 14px !important;

--- a/utils/PresetsDocBlock/styles.css
+++ b/utils/PresetsDocBlock/styles.css
@@ -1,0 +1,76 @@
+.presets-container {
+  width: 100% !important;
+  margin: 32px 0 !important;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.name {
+  color: #111112;
+  font-family: 'Lato' !important;
+  font-size: 20px !important;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 120%; /* 43.2px */
+  letter-spacing: 0.432px;
+  width: 168px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+.token-name {
+  padding-top: 12px;
+  color: #F0F;
+  font-family: 'Lato' !important;
+  font-size: 13px !important;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 120%; /* 43.2px */
+  letter-spacing: 0.432px;
+}
+
+.tokens {
+  width: 435px !important;
+  margin: 0 65px 0 165px !important;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+}
+
+.tokens .token {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  padding-top: 4px;
+}
+
+.tokens .token .key {
+  color: #111112;
+  font-family: 'Lato' !important;
+  font-size: 14px !important;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 150%; /* 24px */
+  letter-spacing: 0.192px;
+  margin-right: 10px !important;
+}
+
+.tokens .token .value {
+  color: #F0F;
+  font-feature-settings: 'clig' off, 'liga' off;
+  font-family: 'Lato' !important;
+  font-size: 14px !important;
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+  text-transform: uppercase;
+}
+
+.preview {
+  width: 344px !important;
+}


### PR DESCRIPTION
# Contexto
Esse PR cria um documento para documentar os presets de tipografia. E, para exibir os estilos, cria um helper - `toWebPreset` - para converter valores absolutos em pixel, nos casos de uso web-only. 

# Mudanças
![Captura de Tela 2023-08-24 às 15 03 03](https://github.com/geekie/geekie-design-system/assets/29842092/2e8100af-8aa7-4a9f-a5c9-62d37f63a89a)
![Captura de Tela 2023-08-24 às 15 03 09](https://github.com/geekie/geekie-design-system/assets/29842092/012fbe02-71cb-44ce-af4a-54df3dc0a5ad)
![Captura de Tela 2023-08-24 às 15 03 15](https://github.com/geekie/geekie-design-system/assets/29842092/cafbe354-1875-4c61-908a-5318d32665cb)


# Como testar
Verifique a documentação das pré-definições no storybook;
Verifique que é possível usá-las no SGLearner, em casos web only - com o helper novo.
