### PR TITLE
Renomeia a pasta build/tokens para built-tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 node_modules/
 
 #Build folder
-build/
+built-tokens/
 
 # TypeScript cache
 *.tsbuildinfo

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,1 @@
-build
+built-tokens

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Atualmente usamos:
 
 ## Como rodar
 
-Primeiro, garanta que os tokens foram gerados corretamente, rodando o script: `yarn build-tokens` - _Você pode conferir os tokens gerados na pasta `/build/tokens`_.
+Primeiro, garanta que os tokens foram gerados corretamente, rodando o script: `yarn build-tokens` - _Você pode conferir os tokens gerados na pasta `/built-tokens`_.
 
 Depois, para inicializar o storybook, rode o script: `yarn storybook`.
 
@@ -87,7 +87,7 @@ A **resposta rápida** é: rode o script
 
 `yarn build-tokens`
 
-E os tokens serão construídos na pasta `/build/tokens`.
+E os tokens serão construídos na pasta `/built-tokens`.
 
 Usamos um script customizado, para garantir que exportamos um arquivo correto para documentar os tokens no storybook. Detalharemos esse assunto um pouco mais à frente.
 
@@ -107,7 +107,7 @@ As platforms são definidas no formato:
   "platforms": {
     "scss": {
       "transformGroup": "scss",
-      "buildPath": "build/tokens/scss/",
+      "buildPath": "built-tokens/scss/",
       "files": [
         {
           "destination": "_variables.scss",
@@ -125,7 +125,7 @@ Já no _script de build_ temos definidos um [custom-transform](https://amzn.gith
 Como já comentado anteriormente, criamos um processo um pouco mais automatizado para criar os tokens e documentá-los no storybook.
 
 Nesse processo, usamos um addon para o storybook - [storybook-design-token](https://github.com/UX-and-I/storybook-design-token) - que consegue documentar e gerar previews dos tokens.
-Esse addon precisa de um arquivo, em um formato específico, chamado de [presenters](https://github.com/UX-and-I/storybook-design-token/tree/v3#available-presenters) pelo addon, que é criado na construição dos tokens - através do style-dictionary - encontrado na pasta `/build/tokens/scss/_variables_with_headers.scss`. Esse formato é definido no _script de build_, em `DESIGN_TOKEN_CATEGORIES_BY_PREFIX`.
+Esse addon precisa de um arquivo, em um formato específico, chamado de [presenters](https://github.com/UX-and-I/storybook-design-token/tree/v3#available-presenters) pelo addon, que é criado na construição dos tokens - através do style-dictionary - encontrado na pasta `/built-tokens/scss/_variables_with_headers.scss`. Esse formato é definido no _script de build_, em `DESIGN_TOKEN_CATEGORIES_BY_PREFIX`.
 
 Então, para **documentar um token**, após terminar o processo descrito anteriormente, vale conferir se o _script de build_ já tem a categoria necessária - se não, criá-la de acordo com os [presenters](https://github.com/UX-and-I/storybook-design-token/tree/v3#available-presenters) suportados pelo addon.
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "node": ">=16.17.1"
   },
   "files": [
-    "build/**",
+    "built-tokens/**",
     "helpers/**",
     "token-presets/**",
     "tokens.ts"

--- a/token-presets/basic.ts
+++ b/token-presets/basic.ts
@@ -18,7 +18,7 @@ import {
   DSA_LINE_HEIGHT_S,
   DSA_LINE_HEIGHT_XL,
   DSA_LINE_HEIGHT_XS,
-} from '../build/tokens/ts/tokens';
+} from '../built-tokens/js/tokens';
 
 /* Headings */
 export const DSA_BASIC_HEADING_H1_STYLE = {

--- a/token-presets/ludic.ts
+++ b/token-presets/ludic.ts
@@ -18,7 +18,7 @@ import {
   DSA_LINE_HEIGHT_S,
   DSA_LINE_HEIGHT_XL,
   DSA_LINE_HEIGHT_XS,
-} from '../build/tokens/ts/tokens';
+} from '../built-tokens/js/tokens';
 
 /* Headings */
 export const DSA_LUDIC_HEADING_H1_STYLE = {

--- a/token-presets/reading.ts
+++ b/token-presets/reading.ts
@@ -10,7 +10,7 @@ import {
   DSA_LETTER_SPACING_NORMAL,
   DSA_LINE_HEIGHT_M,
   DSA_LINE_HEIGHT_S,
-} from '../build/tokens/ts/tokens';
+} from '../built-tokens/js/tokens';
 
 /* Body (large) */
 export const DSA_READING_BODY_L_NORMAL_STYLE = {

--- a/tokens.ts
+++ b/tokens.ts
@@ -1,2 +1,2 @@
-export * from './build/tokens/ts/tokens';
+export * from './built-tokens/js/tokens';
 export * from './helpers/webOnlyHelpers';

--- a/tokens/config/style-dictionary-config.json
+++ b/tokens/config/style-dictionary-config.json
@@ -3,7 +3,7 @@
   "platforms": {
     "scss": {
       "transformGroup": "custom/scss",
-      "buildPath": "build/tokens/scss/",
+      "buildPath": "built-tokens/scss/",
       "prefix": "dsa",
       "files": [
         {
@@ -18,7 +18,7 @@
     },
     "ts": {
       "transformGroup": "custom/js",
-      "buildPath": "build/tokens/ts/",
+      "buildPath": "built-tokens/js/",
       "prefix": "dsa",
       "files": [
         {


### PR DESCRIPTION
# Contexto
Atualmente a lib do design system exporta código em TypeScript diretamente. Em vez disso, vamos passar a exportar arquivos `.js` e `d.ts` gerados a partir dos `.ts`. Uma possibilidade seria deixar esses arquivos `.js` e `d.ts` na pasta `build`, mas um entrave é o fato de que a `build` existente também tem arquivos `.ts` a serem processados. Mantendo ela como está, geraríamos uma estrutura confusa, com uma segunda pasta `build` dentro da `build` atual. Mais contexto em https://geekie.slack.com/archives/C0547M0UDHR/p16928266654310291. 

# Mudanças
Para evitar a build-ception, optei por renomear a pasta `build` existente para `built-tokens` (e as referências a ela de acordo). Provavelmente os arquivos `.js` e `.d.ts` vão passar a ficar na `build`, num commit por vir.

# Como testar
* Rodei `yarn build-tokens` e `yarn storybook` e vi que o Storybook continua se comportando como antes
* Vi que o import de tokens no SGLearner continua funcionando