### PR TITLE
Adiciona `as const` nas declarações dos presets

### DIFF
--- a/token-presets/basic.ts
+++ b/token-presets/basic.ts
@@ -27,7 +27,7 @@ export const DSA_BASIC_HEADING_H1_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_WIDE,
   lineHeight: DSA_LINE_HEIGHT_XL,
-};
+} as const;
 
 export const DSA_BASIC_HEADING_H2_STYLE = {
   fontFamily: DSA_FONT_FAMILY_BASIC,
@@ -35,7 +35,7 @@ export const DSA_BASIC_HEADING_H2_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_L,
-};
+} as const;
 
 export const DSA_BASIC_HEADING_H3_STYLE = {
   fontFamily: DSA_FONT_FAMILY_BASIC,
@@ -43,7 +43,7 @@ export const DSA_BASIC_HEADING_H3_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 /* Body (large) */
 export const DSA_BASIC_BODY_L_NORMAL_STYLE = {
@@ -52,7 +52,7 @@ export const DSA_BASIC_BODY_L_NORMAL_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 export const DSA_BASIC_BODY_L_BOLD_STYLE = {
   fontFamily: DSA_FONT_FAMILY_BASIC,
@@ -60,7 +60,7 @@ export const DSA_BASIC_BODY_L_BOLD_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 export const DSA_BASIC_BODY_L_ITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_BASIC,
@@ -69,7 +69,7 @@ export const DSA_BASIC_BODY_L_ITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 export const DSA_BASIC_BODY_L_BOLDITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_BASIC,
@@ -78,7 +78,7 @@ export const DSA_BASIC_BODY_L_BOLDITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 /* Body (medium) */
 export const DSA_BASIC_BODY_M_NORMAL_STYLE = {
@@ -87,7 +87,7 @@ export const DSA_BASIC_BODY_M_NORMAL_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 export const DSA_BASIC_BODY_M_BOLD_STYLE = {
   fontFamily: DSA_FONT_FAMILY_BASIC,
@@ -95,7 +95,7 @@ export const DSA_BASIC_BODY_M_BOLD_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 export const DSA_BASIC_BODY_M_ITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_BASIC,
@@ -104,7 +104,7 @@ export const DSA_BASIC_BODY_M_ITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 export const DSA_BASIC_BODY_M_BOLDITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_BASIC,
@@ -113,7 +113,7 @@ export const DSA_BASIC_BODY_M_BOLDITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 /* Body (small) */
 export const DSA_BASIC_BODY_S_NORMAL_STYLE = {
@@ -122,7 +122,7 @@ export const DSA_BASIC_BODY_S_NORMAL_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 export const DSA_BASIC_BODY_S_BOLD_STYLE = {
   fontFamily: DSA_FONT_FAMILY_BASIC,
@@ -130,7 +130,7 @@ export const DSA_BASIC_BODY_S_BOLD_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 export const DSA_BASIC_BODY_S_ITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_BASIC,
@@ -139,7 +139,7 @@ export const DSA_BASIC_BODY_S_ITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 export const DSA_BASIC_BODY_S_BOLDITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_BASIC,
@@ -148,7 +148,7 @@ export const DSA_BASIC_BODY_S_BOLDITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 /* Body (extra small) */
 export const DSA_BASIC_BODY_XS_NORMAL_STYLE = {
@@ -157,7 +157,7 @@ export const DSA_BASIC_BODY_XS_NORMAL_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 export const DSA_BASIC_BODY_XS_BOLD_STYLE = {
   fontFamily: DSA_FONT_FAMILY_BASIC,
@@ -165,7 +165,7 @@ export const DSA_BASIC_BODY_XS_BOLD_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 export const DSA_BASIC_BODY_XS_ITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_BASIC,
@@ -174,7 +174,7 @@ export const DSA_BASIC_BODY_XS_ITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 export const DSA_BASIC_BODY_XS_BOLDITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_BASIC,
@@ -183,7 +183,7 @@ export const DSA_BASIC_BODY_XS_BOLDITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 /* Body (extra extra small) */
 export const DSA_BASIC_BODY_XXS_NORMAL_STYLE = {
@@ -192,4 +192,4 @@ export const DSA_BASIC_BODY_XXS_NORMAL_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_WIDE,
   lineHeight: DSA_LINE_HEIGHT_XS,
-};
+} as const;

--- a/token-presets/ludic.ts
+++ b/token-presets/ludic.ts
@@ -27,7 +27,7 @@ export const DSA_LUDIC_HEADING_H1_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_WIDE,
   lineHeight: DSA_LINE_HEIGHT_XL,
-};
+} as const;
 
 export const DSA_LUDIC_HEADING_H2_STYLE = {
   fontFamily: DSA_FONT_FAMILY_LUDIC,
@@ -35,7 +35,7 @@ export const DSA_LUDIC_HEADING_H2_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_L,
-};
+} as const;
 
 export const DSA_LUDIC_HEADING_H3_STYLE = {
   fontFamily: DSA_FONT_FAMILY_LUDIC,
@@ -43,7 +43,7 @@ export const DSA_LUDIC_HEADING_H3_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 /* Body (large) */
 export const DSA_LUDIC_BODY_L_NORMAL_STYLE = {
@@ -52,7 +52,7 @@ export const DSA_LUDIC_BODY_L_NORMAL_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 export const DSA_LUDIC_BODY_L_BOLD_STYLE = {
   fontFamily: DSA_FONT_FAMILY_LUDIC,
@@ -60,7 +60,7 @@ export const DSA_LUDIC_BODY_L_BOLD_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 export const DSA_LUDIC_BODY_L_ITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_LUDIC,
@@ -69,7 +69,7 @@ export const DSA_LUDIC_BODY_L_ITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 export const DSA_LUDIC_BODY_L_BOLDITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_LUDIC,
@@ -78,7 +78,7 @@ export const DSA_LUDIC_BODY_L_BOLDITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 /* Body (medium) */
 export const DSA_LUDIC_BODY_M_NORMAL_STYLE = {
@@ -87,7 +87,7 @@ export const DSA_LUDIC_BODY_M_NORMAL_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 export const DSA_LUDIC_BODY_M_BOLD_STYLE = {
   fontFamily: DSA_FONT_FAMILY_LUDIC,
@@ -95,7 +95,7 @@ export const DSA_LUDIC_BODY_M_BOLD_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 export const DSA_LUDIC_BODY_M_ITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_LUDIC,
@@ -104,7 +104,7 @@ export const DSA_LUDIC_BODY_M_ITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 export const DSA_LUDIC_BODY_M_BOLDITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_LUDIC,
@@ -113,7 +113,7 @@ export const DSA_LUDIC_BODY_M_BOLDITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 /* Body (small) */
 export const DSA_LUDIC_BODY_S_NORMAL_STYLE = {
@@ -122,7 +122,7 @@ export const DSA_LUDIC_BODY_S_NORMAL_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 export const DSA_LUDIC_BODY_S_BOLD_STYLE = {
   fontFamily: DSA_FONT_FAMILY_LUDIC,
@@ -130,7 +130,7 @@ export const DSA_LUDIC_BODY_S_BOLD_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 export const DSA_LUDIC_BODY_S_ITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_LUDIC,
@@ -139,7 +139,7 @@ export const DSA_LUDIC_BODY_S_ITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 export const DSA_LUDIC_BODY_S_BOLDITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_LUDIC,
@@ -148,7 +148,7 @@ export const DSA_LUDIC_BODY_S_BOLDITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 /* Body (extra small) */
 export const DSA_LUDIC_BODY_XS_NORMAL_STYLE = {
@@ -157,7 +157,7 @@ export const DSA_LUDIC_BODY_XS_NORMAL_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 export const DSA_LUDIC_BODY_XS_BOLD_STYLE = {
   fontFamily: DSA_FONT_FAMILY_LUDIC,
@@ -165,7 +165,7 @@ export const DSA_LUDIC_BODY_XS_BOLD_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 export const DSA_LUDIC_BODY_XS_ITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_LUDIC,
@@ -174,7 +174,7 @@ export const DSA_LUDIC_BODY_XS_ITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 export const DSA_LUDIC_BODY_XS_BOLDITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_LUDIC,
@@ -183,7 +183,7 @@ export const DSA_LUDIC_BODY_XS_BOLDITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 /* Body (extra extra small) */
 export const DSA_LUDIC_BODY_XXS_NORMAL_STYLE = {
@@ -192,4 +192,4 @@ export const DSA_LUDIC_BODY_XXS_NORMAL_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_WIDE,
   lineHeight: DSA_LINE_HEIGHT_XS,
-};
+} as const;

--- a/token-presets/reading.ts
+++ b/token-presets/reading.ts
@@ -19,7 +19,7 @@ export const DSA_READING_BODY_L_NORMAL_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 export const DSA_READING_BODY_L_BOLD_STYLE = {
   fontFamily: DSA_FONT_FAMILY_READING,
@@ -27,7 +27,7 @@ export const DSA_READING_BODY_L_BOLD_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 export const DSA_READING_BODY_L_ITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_READING,
@@ -36,7 +36,7 @@ export const DSA_READING_BODY_L_ITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 export const DSA_READING_BODY_L_BOLDITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_READING,
@@ -45,7 +45,7 @@ export const DSA_READING_BODY_L_BOLDITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 /* Body (medium) */
 export const DSA_READING_BODY_M_NORMAL_STYLE = {
@@ -54,7 +54,7 @@ export const DSA_READING_BODY_M_NORMAL_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 export const DSA_READING_BODY_M_BOLD_STYLE = {
   fontFamily: DSA_FONT_FAMILY_READING,
@@ -62,7 +62,7 @@ export const DSA_READING_BODY_M_BOLD_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 export const DSA_READING_BODY_M_ITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_READING,
@@ -71,7 +71,7 @@ export const DSA_READING_BODY_M_ITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 export const DSA_READING_BODY_M_BOLDITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_READING,
@@ -80,7 +80,7 @@ export const DSA_READING_BODY_M_BOLDITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_M,
-};
+} as const;
 
 /* Body (small) */
 export const DSA_READING_BODY_S_NORMAL_STYLE = {
@@ -89,7 +89,7 @@ export const DSA_READING_BODY_S_NORMAL_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 export const DSA_READING_BODY_S_BOLD_STYLE = {
   fontFamily: DSA_FONT_FAMILY_READING,
@@ -97,7 +97,7 @@ export const DSA_READING_BODY_S_BOLD_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 export const DSA_READING_BODY_S_ITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_READING,
@@ -106,7 +106,7 @@ export const DSA_READING_BODY_S_ITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 export const DSA_READING_BODY_S_BOLDITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_READING,
@@ -115,7 +115,7 @@ export const DSA_READING_BODY_S_BOLDITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 /* Body (extra small) */
 export const DSA_READING_BODY_XS_NORMAL_STYLE = {
@@ -124,7 +124,7 @@ export const DSA_READING_BODY_XS_NORMAL_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 export const DSA_READING_BODY_XS_BOLD_STYLE = {
   fontFamily: DSA_FONT_FAMILY_READING,
@@ -132,7 +132,7 @@ export const DSA_READING_BODY_XS_BOLD_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 export const DSA_READING_BODY_XS_ITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_READING,
@@ -141,7 +141,7 @@ export const DSA_READING_BODY_XS_ITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_NORMAL,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;
 
 export const DSA_READING_BODY_XS_BOLDITALIC_STYLE = {
   fontFamily: DSA_FONT_FAMILY_READING,
@@ -150,4 +150,4 @@ export const DSA_READING_BODY_XS_BOLDITALIC_STYLE = {
   fontWeight: DSA_FONT_WEIGHT_BOLD,
   letterSpacing: DSA_LETTER_SPACING_NORMAL,
   lineHeight: DSA_LINE_HEIGHT_S,
-};
+} as const;


### PR DESCRIPTION
# Contexto
Ao tentar usar um preset de tipografia no SGLearner, havia um erro de TypeScript:

```
Type '{ fontFamily: string; fontSize: number; fontWeight: string; letterSpacing: number; lineHeight: number; }' is not assignable to type 'TextStyle'.
  Types of property 'fontWeight' are incompatible.
    Type 'string' is not assignable to type '"normal" | "bold" | "100" | "200" | "300" | "400" | "500" | "600" | "700" | "800" | "900" | undefined'.
```

O problema vinha do fato de que os presets estavam escritos de forma que, por exemplo,  o `fontSize` ficava tipado como uma string arbitrária. Isso é incompatível com a lista de valores permitidos para o estilo, e por isso precisaríamos de uma tipagem mais estrita nos presets.

# Mudanças
Como explicado [no Discourse](https://discourse.geekie.com.br/t/typescript-e-as-const-quando-usar/365), nesses casos é possível usar o `as const` para resolver o problema da tipagem. Então apliquei na definição de todos os presets de tipografia.

# Como testar
* Adicionar a lib do DS com a modificação como dependência do SGLearner
* Importar algum preset de tipografia e aplicá-lo em alguma tela
* Ver que o erro de TS citado deixa de acontecer, e que o estilo do preset é aplicado adequadamente