### PR TITLE
Ajuste, na documentação, dos nomes dos tokens e presets de tipografia

### DIFF
--- a/utils/PresetsDocBlock/index.tsx
+++ b/utils/PresetsDocBlock/index.tsx
@@ -52,7 +52,7 @@ const PresetsDocBlock: React.FC<PresetsDocBlockProps> = (props) => {
                           .replace(/_/g, '')
                           .includes(presetStyle.toLowerCase())
                       ) {
-                        return tokenName;
+                        return `$${tokenName}`;
                       }
                       return null;
                     }

--- a/utils/PresetsDocBlock/index.tsx
+++ b/utils/PresetsDocBlock/index.tsx
@@ -31,7 +31,7 @@ const PresetsDocBlock: React.FC<PresetsDocBlockProps> = (props) => {
         {name}
         <div className="token-name">
           {(Object.keys(allPresets) as PresetName[]).map((presetName) => {
-            if (allPresets[presetName] === preset) return presetName;
+            if (allPresets[presetName] === preset) return `$${presetName}`;
             return null;
           })}
         </div>
@@ -47,12 +47,14 @@ const PresetsDocBlock: React.FC<PresetsDocBlockProps> = (props) => {
                     (tokenName) => {
                       if (
                         tokens[tokenName] === preset[presetStyle] &&
-                        tokenName
-                          .toLowerCase()
-                          .replace(/_/g, '')
-                          .includes(presetStyle.toLowerCase())
+                        Boolean(
+                          (tokenName as string)
+                            .toLowerCase()
+                            .replace(/_/g, '')
+                            .includes(presetStyle.toLowerCase())
+                        )
                       ) {
-                        return tokenName;
+                        return `$${String(tokenName)}`;
                       }
                       return null;
                     }

--- a/utils/PresetsDocBlock/index.tsx
+++ b/utils/PresetsDocBlock/index.tsx
@@ -47,14 +47,12 @@ const PresetsDocBlock: React.FC<PresetsDocBlockProps> = (props) => {
                     (tokenName) => {
                       if (
                         tokens[tokenName] === preset[presetStyle] &&
-                        Boolean(
-                          (tokenName as string)
-                            .toLowerCase()
-                            .replace(/_/g, '')
-                            .includes(presetStyle.toLowerCase())
-                        )
+                        tokenName
+                          .toLowerCase()
+                          .replace(/_/g, '')
+                          .includes(presetStyle.toLowerCase())
                       ) {
-                        return `$${String(tokenName)}`;
+                        return tokenName;
                       }
                       return null;
                     }


### PR DESCRIPTION
# Contexto

De acordo com [essa thread](https://geekie.slack.com/archives/C0547M0UDHR/p1694456011067639?thread_ts=1694438881.836849&cid=C0547M0UDHR), decidimos ajustar e padronizar a nomenclatura dos presets e tokens, na documentação dos presets, para seguir o modelo com prefixo "$".