### PR TITLE
Adiciona tipos para o helper dos web presets

### DIFF
--- a/helpers/webOnlyHelpers.ts
+++ b/helpers/webOnlyHelpers.ts
@@ -1,3 +1,5 @@
+import {  type WebPreset, type Preset } from '../token-presets';
+
 const toPx = (value: number): string => {
   return `${value}px`;
 };
@@ -8,8 +10,6 @@ export const toWebToken = (token: number): string => {
 };
 
 // Essa função foi criada para resolver o uso dos presets em casos web-only
-export const toWebPreset = <Preset extends { lineHeight: number }>(
-  preset: Preset
-): Preset & { lineHeight: string } => {
+export const toWebPreset = (preset: Preset): WebPreset => {
   return { ...preset, lineHeight: toPx(preset.lineHeight) };
 };

--- a/token-presets/index.ts
+++ b/token-presets/index.ts
@@ -1,3 +1,15 @@
 export * from './basic';
 export * from './ludic';
 export * from './reading';
+
+export interface Preset {
+  fontFamily: string;
+  fontSize: number;
+  fontWeight: string;
+  letterSpacing: number;
+  lineHeight: number;
+}
+
+export type WebPreset = Omit<Preset, 'lineHeight'> & {
+  lineHeight: string;
+};


### PR DESCRIPTION
# Contexto
No SGLearner, recebi alguns erros que impediam o uso do helper `toWebPreset`, nas declarações de estilo.

# Mudanças
Decidi criar dois tipos `Preset` e `WebPreset` para corrigir a tipagem do helper. Mas, esses tipos não são usados na definição dos presets, em si.

# Como testar
