### PR TITLE
Adiciona um breve guia de uso para o CMS

### DIFF
--- a/stories/docs/guides/guia-cms.stories.mdx
+++ b/stories/docs/guides/guia-cms.stories.mdx
@@ -38,7 +38,7 @@ Ou seja, os presets e tokens já estão disponíveis para uso nos demais arquivo
 
 &nbsp;
 
-## Uso de tokens em arquivos  LESS
+## Uso de tokens em arquivos LESS
 
 Escolhemos usar as variáveis less para aplicar nossos tokens.
 De forma simples, para aplicar o token de cor `DSA_COLOR_BUTTON_MEDIUM`, como cor de um texto, basta fazer:

--- a/stories/docs/guides/guia-cms.stories.mdx
+++ b/stories/docs/guides/guia-cms.stories.mdx
@@ -38,7 +38,7 @@ Ou seja, os presets e tokens já estão disponíveis para uso nos demais arquivo
 
 &nbsp;
 
-## Uso de tokens em arquivos LESSS
+## Uso de tokens em arquivos  LESS
 
 Escolhemos usar as variáveis less para aplicar nossos tokens.
 De forma simples, para aplicar o token de cor `DSA_COLOR_BUTTON_MEDIUM`, como cor de um texto, basta fazer:
@@ -51,7 +51,7 @@ De forma simples, para aplicar o token de cor `DSA_COLOR_BUTTON_MEDIUM`, como co
 
 Esse conceito se aplica aos demais tokens, e, basicamente, é a mesma forma como usamos tokens nos casos CSS-in-JS.
 
-## Uso de presets em arquivos LESSS
+## Uso de presets em arquivos LESS
 
 Para os presets, decidimos aplicar classes para agrupar e aplicar o conjunto de tokens que o formam.
 Para usar presets, temos dois casos de usos possíveis:

--- a/stories/docs/guides/guia-cms.stories.mdx
+++ b/stories/docs/guides/guia-cms.stories.mdx
@@ -1,0 +1,85 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import SpecFigmaCompleta from '../../../public/images/spec-figma-completa.png';
+import SpecFigmaAbaDev from '../../../public/images/spec-figma-aba-dev.png';
+import SpecFigmaCor from '../../../public/images/spec-figma-cor.png';
+import SpecFigmaPreset from '../../../public/images/spec-figma-preset.png';
+import PresetH2 from '../../../public/images/preset-h2.png';
+import TokenCorNeutralXXDark from '../../../public/images/token-cor-neutral-xxdark.png';
+import SpecFigmaNovaCapa from '../../../public/images/spec-figma-nova-capa.png';
+
+<Meta title="Documentação/Guias/Guia para o CMS" />
+
+# Tokens e Presets | Guia de uso para o CMS
+
+#### Esse guia usa conceitos definidos no [Tokens e Presets | Guia de uso para engenharia](/docs/documentação-guias-tokens-e-presets--docs). Recomendados que você leia esse outro guia, antes de continuar com a leitura daqui.
+
+**Para saber detalhes da implementação, consulte o [README](https://github.com/geekie/geekie-design-system/blob/master/README.md) do repositório.**
+
+---
+
+Criamos o design system para atender, além do SGLearner, outros produtos. O primeiro testado foi o CMS.
+Como existem algumas diferenças dos casos de uso que descrevemos no guia anterior, focado no SGLearner, esse guia descreve as particularidades que encontramos ao testar o DS no CMS.
+
+&nbsp;
+## Casos de uso
+
+Basicamente, temos **dois casos de uso do DS no CMS**, que são:
+
+- Uso de tokens e presets nas **classes de estilo LESS**;
+- Uso de tokens e presets nos **componentes que escrevem estilos no JS**;
+
+Para esse segundo caso, o que foi descrito no [guia de uso para engenharia](/docs/documentação-guias-tokens-e-presets--docs) ainda é a forma adequada de usar o design system no CMS - no caso de CSS-in-JS.
+
+Agora, para usar o DS em arquivos LESS, algumas coisas são distintas. É o que vamos discutir a seguir:
+
+Importamos o DS no arquivo `main.less`, da seguinte forma:
+
+```css
+/* Design System */
+@import "../../../../../../../node_modules/@geekie/design-system/build/less/_presets.less";
+@import "../../../../../../../node_modules/@geekie/design-system/build/less/_tokens.less";
+```
+
+Ou seja, os presets e tokens já estão disponíveis para uso nos demais arquivos LESS - sem ser necessário importá-los novamente.
+
+&nbsp;
+## Uso de tokens em arquivos LESSS
+
+Escolhemos usar as variáveis less para aplicar nossos tokens.
+De forma simples, para aplicar o token de cor `DSA_COLOR_BUTTON_MEDIUM`, como cor de um texto, basta fazer:
+```css
+.card {
+    color: @DSA_COLOR_BUTTON_MEDIUM;
+}
+```
+
+Esse conceito se aplica aos demais tokens, e, basicamente, é a mesma forma como usamos tokens nos casos CSS-in-JS.
+
+## Uso de presets em arquivos LESSS
+
+Para os presets, decidimos aplicar classes para agrupar e aplicar o conjunto de tokens que o formam.
+Para usar presets, temos dois casos de usos possíveis:
+  - Usar o preset diretamente no `className` do elemento;
+  - Usar o preset em outra classe LESS, que estiliza o elemento;
+
+Aqui, recomendamos e descreveremos somente o segundo caso de uso. Decidimos torná-lo uma boa prática, já que possibilita centralizar os estilos, e, nos pareceu mais fácil para entender as modificações durante o CR.
+
+Então, para aplicar presets nas classes LESS, usaremos o seletor `&:extend` - [referência aqui](https://lesscss.org/features/#extend-feature) - para importar os estilos diretamente em outra classe. Como no exemplo:
+
+```css
+.texto1 {
+    &:extend(.dsa-basic-body-m-normal-style);
+    color: @DSA_COLOR_BUTTON_MEDIUM;
+}
+
+.texto2{
+    &:extend(.dsa-basic-body-m-bold-style);
+}
+```
+
+
+## Exemplos no codebase
+
+Para testar os casos de uso aqui descritos, criamos um diff, que aplica os conceitos que descrevemos:
+
+- [[DS] Adiciona tokens e presets na edição de capítulos](https://phabricator.geekie.com.br/D26737)

--- a/stories/docs/guides/guia-cms.stories.mdx
+++ b/stories/docs/guides/guia-cms.stories.mdx
@@ -21,6 +21,7 @@ Criamos o design system para atender, além do SGLearner, outros produtos. O pri
 Como existem algumas diferenças dos casos de uso que descrevemos no guia anterior, focado no SGLearner, esse guia descreve as particularidades que encontramos ao testar o DS no CMS.
 
 &nbsp;
+
 ## Casos de uso
 
 Basicamente, temos **dois casos de uso do DS no CMS**, que são:
@@ -36,20 +37,22 @@ Importamos o DS no arquivo `main.less`, da seguinte forma:
 
 ```css
 /* Design System */
-@import "../../../../../../../node_modules/@geekie/design-system/build/less/_presets.less";
-@import "../../../../../../../node_modules/@geekie/design-system/build/less/_tokens.less";
+@import '../../../../../../../node_modules/@geekie/design-system/build/less/_presets.less';
+@import '../../../../../../../node_modules/@geekie/design-system/build/less/_tokens.less';
 ```
 
 Ou seja, os presets e tokens já estão disponíveis para uso nos demais arquivos LESS - sem ser necessário importá-los novamente.
 
 &nbsp;
+
 ## Uso de tokens em arquivos LESSS
 
 Escolhemos usar as variáveis less para aplicar nossos tokens.
 De forma simples, para aplicar o token de cor `DSA_COLOR_BUTTON_MEDIUM`, como cor de um texto, basta fazer:
+
 ```css
 .card {
-    color: @DSA_COLOR_BUTTON_MEDIUM;
+  color: @DSA_COLOR_BUTTON_MEDIUM;
 }
 ```
 
@@ -59,8 +62,9 @@ Esse conceito se aplica aos demais tokens, e, basicamente, é a mesma forma como
 
 Para os presets, decidimos aplicar classes para agrupar e aplicar o conjunto de tokens que o formam.
 Para usar presets, temos dois casos de usos possíveis:
-  - Usar o preset diretamente no `className` do elemento;
-  - Usar o preset em outra classe LESS, que estiliza o elemento;
+
+- Usar o preset diretamente no `className` do elemento;
+- Usar o preset em outra classe LESS, que estiliza o elemento;
 
 Aqui, recomendamos e descreveremos somente o segundo caso de uso. Decidimos torná-lo uma boa prática, já que possibilita centralizar os estilos, e, nos pareceu mais fácil para entender as modificações durante o CR.
 
@@ -68,15 +72,14 @@ Então, para aplicar presets nas classes LESS, usaremos o seletor `&:extend` - [
 
 ```css
 .texto1 {
-    &:extend(.dsa-basic-body-m-normal-style);
-    color: @DSA_COLOR_BUTTON_MEDIUM;
+  &:extend(.dsa-basic-body-m-normal-style);
+  color: @DSA_COLOR_BUTTON_MEDIUM;
 }
 
-.texto2{
-    &:extend(.dsa-basic-body-m-bold-style);
+.texto2 {
+  &:extend(.dsa-basic-body-m-bold-style);
 }
 ```
-
 
 ## Exemplos no codebase
 

--- a/stories/docs/guides/guia-cms.stories.mdx
+++ b/stories/docs/guides/guia-cms.stories.mdx
@@ -1,11 +1,4 @@
 import { Meta } from '@storybook/addon-docs/blocks';
-import SpecFigmaCompleta from '../../../public/images/spec-figma-completa.png';
-import SpecFigmaAbaDev from '../../../public/images/spec-figma-aba-dev.png';
-import SpecFigmaCor from '../../../public/images/spec-figma-cor.png';
-import SpecFigmaPreset from '../../../public/images/spec-figma-preset.png';
-import PresetH2 from '../../../public/images/preset-h2.png';
-import TokenCorNeutralXXDark from '../../../public/images/token-cor-neutral-xxdark.png';
-import SpecFigmaNovaCapa from '../../../public/images/spec-figma-nova-capa.png';
 
 <Meta title="Documentação/Guias/Guia para o CMS" />
 

--- a/stories/docs/guides/tokens-e-presets.stories.mdx
+++ b/stories/docs/guides/tokens-e-presets.stories.mdx
@@ -12,8 +12,8 @@ import SpecFigmaNovaCapa from '../../../public/images/spec-figma-nova-capa.png';
 # Tokens e Presets | Guia de uso para engenharia
 
 #### Atualmente, nossos tokens englobam [Cores](/docs/design-tokens-cores--docs) e [Tipografia](/docs/design-tokens-tipografia-tokens--docs).
-#### Esse guia foi escrito para descrever cenários de uso encontrados no SGLearner. Caso queira saber como usar o DS no CMS, leia o [Guia de uso para o CMS](/docs/documentação-guias-guia-para-o-cms--docs).
 
+#### Esse guia foi escrito para descrever cenários de uso encontrados no SGLearner. Caso queira saber como usar o DS no CMS, leia o [Guia de uso para o CMS](/docs/documentação-guias-guia-para-o-cms--docs).
 
 **Para saber detalhes da implementação, consulte o [README](https://github.com/geekie/geekie-design-system/blob/master/README.md) do repositório.**
 

--- a/stories/docs/guides/tokens-e-presets.stories.mdx
+++ b/stories/docs/guides/tokens-e-presets.stories.mdx
@@ -12,6 +12,8 @@ import SpecFigmaNovaCapa from '../../../public/images/spec-figma-nova-capa.png';
 # Tokens e Presets | Guia de uso para engenharia
 
 #### Atualmente, nossos tokens englobam [Cores](/docs/design-tokens-cores--docs) e [Tipografia](/docs/design-tokens-tipografia-tokens--docs).
+#### Esse guia foi escrito para descrever cenários de uso encontrados no SGLearner. Caso queira saber como usar o DS no CMS, leia o [Guia de uso para o CMS](/docs/documentação-guias-guia-para-o-cms--docs).
+
 
 **Para saber detalhes da implementação, consulte o [README](https://github.com/geekie/geekie-design-system/blob/master/README.md) do repositório.**
 


### PR DESCRIPTION
# Contexto
Escrevi um breve guia de uso, dos tokens de cores e presets de tipografia, para o caso de uso específico dos arquivos LESS, para o CMS. 

# Mudanças
-

# Como testar
-
