### PR TITLE
Criar função para definir o valor dos tokens semânticos, de acordo com o tema

### DIFF
--- a/themes/getThemeToken.ts
+++ b/themes/getThemeToken.ts
@@ -1,0 +1,30 @@
+import * as defaultTokens from '../built-tokens/js/semantic-tokens';
+import * as darkTokens from '../built-tokens/js/dark-tokens';
+import * as lightTokens from '../built-tokens/js/light-tokens';
+import type { ThemeType } from './themes';
+
+function getThemeToken(
+  theme: ThemeType,
+  tokenName: keyof typeof darkTokens
+): string {
+  if (theme === 'dark') {
+    return darkTokens[tokenName];
+  } else if (theme === 'light') {
+    return lightTokens[tokenName];
+  }
+
+  return defaultTokens[tokenName];
+}
+
+export const getThemeTokenValue = (token: string, theme: ThemeType): string => {
+  if (typeof token === 'string' && token.includes('DSA_COLOR')) {
+    const regexpSize = /(DSA_COLOR_TEXT_|DSA_COLOR_BG_|DSA_COLOR_BORDER_)\w+/;
+    const match = token.match(regexpSize);
+    if (match !== null && match?.length > 0) {
+      const value = getThemeToken(theme, match[0] as keyof typeof darkTokens);
+      const tokenWithValue = token.replace(match[0], value);
+      return tokenWithValue;
+    }
+  }
+  return token;
+};

--- a/tokens.ts
+++ b/tokens.ts
@@ -2,3 +2,4 @@ export * from './built-tokens/js/tokens';
 export * from './built-tokens/js/semantic-tokens';
 
 export * from './helpers/webOnlyHelpers';
+export * from './themes/getThemeToken';


### PR DESCRIPTION
# Contexto
Esse PR adiciona a função getThemeTokenValue, que indentifica e ajusta o valor de um token semântico, de acordo com o tema. Como, incialmente, os tokens semânticos possuem - como valor - o próprio nome, essa função lida com a substituição correta da "string de nome" pelo token de cor.

# Mudanças
- Adiciona o arquivo `themes/getThemeToken`, com o método `getThemeTokenValue`.

# Como testar
--