### PR TITLE
Adiciona o DarkModeEnabledContext para gerenciar o tema ativo

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,7 @@
+export {
+  DarkModeEnabledProvider,
+  useDarkMode,
+} from './themes/DarkModeEnabledContext';
+
 export * from './tokens';
 export * from './token-presets';

--- a/themes/DarkModeEnabledContext.tsx
+++ b/themes/DarkModeEnabledContext.tsx
@@ -1,0 +1,40 @@
+import React, {
+  createContext,
+  useContext,
+  useState,
+  type ReactNode,
+} from 'react';
+
+import { type ThemeType, defaultTheme } from './themes';
+
+interface DarkModeEnabledContextProps {
+  theme: ThemeType;
+  toggleDarkMode: () => void;
+}
+
+const DarkModeEnabledContext = createContext<DarkModeEnabledContextProps>({
+  theme: defaultTheme,
+  // eslint-disable-next-line no-void
+  toggleDarkMode: () => void {},
+});
+
+const DarkModeEnabledProvider: React.FC<{ children: ReactNode }> = ({
+  children,
+}) => {
+  const [theme, setTheme] = useState<ThemeType>('light');
+
+  const toggleDarkMode = (): void => {
+    setTheme((prevTheme) => (prevTheme === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <DarkModeEnabledContext.Provider value={{ theme, toggleDarkMode }}>
+      {children}
+    </DarkModeEnabledContext.Provider>
+  );
+};
+
+const useDarkMode = (): DarkModeEnabledContextProps =>
+  useContext(DarkModeEnabledContext);
+
+export { DarkModeEnabledProvider, useDarkMode };

--- a/themes/themes.ts
+++ b/themes/themes.ts
@@ -1,3 +1,5 @@
 export type ThemeType = 'dark' | 'light';
 
 export const themes: ThemeType[] = ['dark', 'light'];
+
+export const defaultTheme: ThemeType = 'light';


### PR DESCRIPTION
# Contexto

Ao puxar a tarefa da documentação dos tokens semânticos, percebi que precisaria adicionar o controle dos temas para demonstrar a mudança de valores dos tokens. Decidi trazer o controle escrito na POC, e exportá-lo na lib do DS.

# Mudanças
O PR adiciona o context `DarkModeEnabled`, da poc, para gerenciar os temas.

# Como testar
--