### PR TITLE
fix: Readiciona brand colors

### DIFF
--- a/stories/tokens/core/colorTokens.stories.mdx
+++ b/stories/tokens/core/colorTokens.stories.mdx
@@ -5,6 +5,10 @@ import { DesignTokenDocBlock } from 'storybook-design-token';
 
 # Cores
 
+## Brand
+
+<DesignTokenDocBlock categoryName="Brand Colors" showSearch={false} />
+
 ## Neutral
 
 <DesignTokenDocBlock categoryName="Neutral Colors" showSearch={false} />

--- a/tokens/config/customFormats.ts
+++ b/tokens/config/customFormats.ts
@@ -5,6 +5,7 @@ import { formatTokenToWeb } from '../../utils/formatTokenToWeb';
 // headers on the SCSS file, so we generate it accordingly. The code based on the suggestion from
 // https://github.com/amzn/style-dictionary/issues/344#issuecomment-1200826141.
 const DESIGN_TOKEN_CATEGORIES_BY_PREFIX = {
+  DSA_COLOR_BRAND: { categoryName: 'Brand Colors', presenterName: 'Color' },
   DSA_COLOR_NEUTRAL: { categoryName: 'Neutral Colors', presenterName: 'Color' },
   DSA_COLOR_SPECIALPAGE: {
     categoryName: 'Special Page Colors',

--- a/tokens/src/core/color.json
+++ b/tokens/src/core/color.json
@@ -1,5 +1,25 @@
 {
   "color": {
+    "brand": {
+      "cereja": {
+        "value": "#F03246"
+      },
+      "laranja": {
+        "value": "#FF8219"
+      },
+      "amarelo": {
+        "value": "#FFC300"
+      },
+      "verde": {
+        "value": "#32CD91"
+      },
+      "azul": {
+        "value": "#0FC3E6"
+      },
+      "roxo": {
+        "value": "#6146F1"
+      }
+    },
     "neutral": {
       "090": {
         "value": "#FFFFFF"


### PR DESCRIPTION
# Contexto

No PR anterior, acabei me confundindo e achei que removeríamos os brand tokens, que não estavam no figma e tabela de novos tokens brutos. Confirmei com o Cássio, e esses tokens ainda ficarão no DS.

# Mudanças

Esse PR readiciona os brand colors, e ajusta a build - para formatar no modelo esperado pelo plugin do storybook

# Como testar
Rode `yarn preapare` e `yarn storybook`, e verifique que os tokens brand estão documentados corretamente.