### PR TITLE
Corrige erro da async storage

### DIFF
--- a/themes/DarkModeEnabledContext.tsx
+++ b/themes/DarkModeEnabledContext.tsx
@@ -6,12 +6,14 @@ import {
   useState,
   type ReactNode,
 } from 'react';
-
-import AsyncStorage from '@react-native-community/async-storage';
+import type AsyncStorageType from '@react-native-community/async-storage';
 
 import { type ThemeType, defaultTheme } from './themes';
 
-const storeToggledTheme = async (currentTheme: ThemeType): Promise<void> => {
+const storeToggledTheme = async (
+  currentTheme: ThemeType,
+  AsyncStorage: typeof AsyncStorageType
+): Promise<void> => {
   await AsyncStorage.setItem('dsa_theme', currentTheme);
 };
 
@@ -25,9 +27,10 @@ const DarkModeEnabledContext = createContext<DarkModeEnabledContextProps>({
   toggleDarkMode: () => {},
 });
 
-const DarkModeEnabledProvider: React.FC<{ children: ReactNode }> = ({
-  children,
-}) => {
+const DarkModeEnabledProvider: React.FC<{
+  children: ReactNode;
+  AsyncStorage: typeof AsyncStorageType;
+}> = ({ children, AsyncStorage }) => {
   const [theme, setTheme] = useState<ThemeType>(defaultTheme);
 
   useEffect(() => {
@@ -47,7 +50,7 @@ const DarkModeEnabledProvider: React.FC<{ children: ReactNode }> = ({
   const toggleDarkMode = (): void => {
     setTheme((prevTheme) => {
       const currentTheme = prevTheme === 'light' ? 'dark' : 'light';
-      storeToggledTheme(currentTheme).catch((e) => {
+      storeToggledTheme(currentTheme, AsyncStorage).catch((e) => {
         console.log(e);
       });
       return currentTheme;

--- a/themes/__tests__/DarkModeEnabledContext.test.tsx
+++ b/themes/__tests__/DarkModeEnabledContext.test.tsx
@@ -20,7 +20,7 @@ const ThemeToggle = (): React.JSX.Element => {
 
 const customRender = (): any => {
   return render(
-    <DarkModeEnabledProvider>
+    <DarkModeEnabledProvider AsyncStorage={AsyncStorage}>
       <ThemeDisplay />
       <ThemeToggle />
     </DarkModeEnabledProvider>,

--- a/utils/CustomDesignTokenDocBlock/index.tsx
+++ b/utils/CustomDesignTokenDocBlock/index.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../themes/DarkModeEnabledContext';
 import { type ThemeType } from '../../themes/themes';
 import * as allTokens from '../../built-tokens/js/tokens';
+import AsyncStorage from '@react-native-community/async-storage';
 
 type FontStyle = 'normal' | 'italic' | 'oblique';
 
@@ -238,7 +239,7 @@ const CustomDesignTokenDocBlock: React.FC<CustomDesignTokenDocBlockProps> = (
   const { previewType } = props;
 
   return previewType === 'semantic-color' ? (
-    <DarkModeEnabledProvider>
+    <DarkModeEnabledProvider AsyncStorage={AsyncStorage}>
       <ThemeSwitch hideTitle={false} />
 
       <BlockWithCategory {...props} />


### PR DESCRIPTION
# Contexto

Ao rodar os testes no SGLearner, me deparei com o seguinte erro — que acontecia somente nos testes mobile e apontava para a lib do async storage — :
<img width="1072" alt="Screenshot 2024-02-29 at 11 11 09" src="https://github.com/geekie/geekie-design-system/assets/29842092/8500799a-f74b-455b-8ac2-e50226a5c3c5">

Tentei ajustar os mocks, atualizar a biblioteca e segui algumas outras soluções apontadas no SO e nas issues da lib, mas não tive sucesso.
Depois de investigar, entendi que o problema é que, resumidamente, a lib async-storage não é feita para ser consumida através de uma biblioteca de terceiros - ou, pelo menos, não da forma como a lib do DS é organizada/distribuída. O async storage precisa, necessariamente, de configurações adicionais para funcionar no mobile.

No SGLearner também temos essa biblioteca instalada e configurada, além do mock do jest, mas não consegui achar uma forma de configurar, no DS, para evitar o erro nos testes. Me parece que o problema acontece pela falta das configurações específicas dos módulos nativos.

# Mudanças
Como o problema acontece na lib do DS, decidi ajustar o componente - o DarkModeReadyProvider - que consome o async storage, para recebê-lo como prop. Dessa forma, conseguimos resolver o erro, já que o async storage
Acredito que a DX não fique ruim, já que esse componente é chamado somente nos arquivos `app.tsx` - e seremos nós que adicionaremos esse controle de estado.

# Como testar
Buildar a lid do ds e mover para o SGLearner;
Rodar o teste `yarn test rn/js/components/boxes/__tests__/SectionTitleBox.test.tsx`(era um dos que quebrava)