### PR TITLE
muda cor de multimateria

### DIFF
--- a/tokens/src/semantic/color/color.light.json
+++ b/tokens/src/semantic/color/color.light.json
@@ -112,7 +112,7 @@
           "value": "{color.subject.460}"
         },
         "multimateria": {
-          "value": "{color.subject.480}"
+          "value": "{color.subject.320}"
         }
       },
       "eletivas": {


### PR DESCRIPTION
# Contexto

Foram alteradas as cores da matéria "Educação infantil” no platform

# Mudanças

Muda cor da matéria anos iniciais > multimatéria no design system

# Como testar

1 - Entre no storybook 
2 - O DSA_COLOR_SUBJECTS_ANOSINICIAIS_MULTIMATERIA deve ter o valor $DSA_COLOR_SUBJECT_320
