### PR TITLE
Adiciona tokens de breakpoints

### DIFF
--- a/stories/tokens/core/breakpointTokens.stories.mdx
+++ b/stories/tokens/core/breakpointTokens.stories.mdx
@@ -10,8 +10,8 @@ import breakpointTokens from '../../../tokens/src/core/breakpoint.json';
 <CustomDesignTokenDocBlock
   blockType="table"
   presenter="breakpoint"
-  tokens={['small', 'medium', 'large', 'x_large'].map(size => ({
-      name: `$DSA_BREAKPOINT_${size.toUpperCase()}`,
-      value: `${breakpointTokens.breakpoint[size].value}px`,
+  tokens={['small', 'medium', 'large', 'x_large'].map((size) => ({
+    name: `$DSA_BREAKPOINT_${size.toUpperCase()}`,
+    value: `${breakpointTokens.breakpoint[size].value}px`,
   }))}
 />

--- a/stories/tokens/core/breakpointTokens.stories.mdx
+++ b/stories/tokens/core/breakpointTokens.stories.mdx
@@ -1,0 +1,17 @@
+import { Meta } from '@storybook/addon-docs';
+import CustomDesignTokenDocBlock from '../../../utils/CustomDesignTokenDocBlock';
+
+import breakpointTokens from '../../../tokens/src/core/breakpoint.json';
+
+<Meta title="Design Tokens/Tokens/Core/Breakpoints" />
+
+# Breakpoints
+
+<CustomDesignTokenDocBlock
+  blockType="table"
+  presenter="breakpoint"
+  tokens={['small', 'medium', 'large', 'x_large'].map(size => ({
+      name: `$DSA_BREAKPOINT_${size.toUpperCase()}`,
+      value: `${breakpointTokens.breakpoint[size].value}px`,
+  }))}
+/>

--- a/tokens/src/core/breakpoint.json
+++ b/tokens/src/core/breakpoint.json
@@ -1,0 +1,8 @@
+{
+  "breakpoint": {
+    "small": { "value": 576 },
+    "medium": { "value": 992 },
+    "large": { "value": 1200 },
+    "x_large": { "value": 1400 }
+  }
+}

--- a/utils/CustomDesignTokenDocBlock/index.tsx
+++ b/utils/CustomDesignTokenDocBlock/index.tsx
@@ -17,8 +17,8 @@ interface Token {
 }
 interface CustomDesignTokenDocBlockProps {
   blockType: 'table';
-  presenter: 'font-style' | 'color';
-  previewType: 'text' | 'semantic-color';
+  presenter: 'font-style' | 'color' | 'breakpoint';
+  previewType: 'text' | 'semantic-color' | undefined;
   tokens: Token[];
   categories?: string[];
   useLeftCopyIcon: boolean;
@@ -93,6 +93,7 @@ const Block: React.FC<CustomDesignTokenDocBlockProps> = (props) => {
   const { theme } = useDarkMode();
 
   const isSemantic = previewType === 'semantic-color';
+  const hasPreview = previewType !== undefined;
 
   return (
     <div className="design-token-container">
@@ -109,7 +110,9 @@ const Block: React.FC<CustomDesignTokenDocBlockProps> = (props) => {
                     </th>
                   ) : null}
                   <th className={isSemantic ? 'isSemantic' : ''}>Value</th>
-                  <th className={isSemantic ? 'isSemantic' : ''}>Preview</th>
+                  {hasPreview && (
+                    <th className={isSemantic ? 'isSemantic' : ''}>Preview</th>
+                  )}
                 </tr>
               </thead>
               <tbody>
@@ -163,20 +166,24 @@ const Block: React.FC<CustomDesignTokenDocBlockProps> = (props) => {
                           </span>
                         </div>
                       </td>
-                      <td className={isSemantic ? 'isSemantic' : ''}>
-                        <div style={previewType === 'text' ? previewStyle : {}}>
-                          {previewType === 'text' ? (
-                            'Lorem ipsum'
-                          ) : previewType === 'semantic-color' ? (
-                            <div className="color-block-container">
-                              <div
-                                className="color-block"
-                                style={previewStyle}
-                              />
-                            </div>
-                          ) : null}
-                        </div>
-                      </td>
+                      {hasPreview && (
+                        <td className={isSemantic ? 'isSemantic' : ''}>
+                          <div
+                            style={previewType === 'text' ? previewStyle : {}}
+                          >
+                            {previewType === 'text' ? (
+                              'Lorem ipsum'
+                            ) : previewType === 'semantic-color' ? (
+                              <div className="color-block-container">
+                                <div
+                                  className="color-block"
+                                  style={previewStyle}
+                                />
+                              </div>
+                            ) : null}
+                          </div>
+                        </td>
+                      )}
                     </tr>
                   );
                 })}


### PR DESCRIPTION
# Contexto
Estamos trabalhando na responsivação do app web do Geekie One. [Conversando com o Cássio](https://geekie.slack.com/archives/C08CRP0S0EL/p1739889871734069), vimos que seria desejável termos tokens de breakpoints para padronizarmos esses valores. Como discutido na thread, vamos seguir com os mesmos valores de tokens do [Iris](https://iris-ds.arcotech.io/?path=/docs/sobre-tokens-lista-de-tokens-breakpoints--docs).

# Mudanças
* Criei um json com os tokens em `tokens/src/core/breakpoint.json`
* Criei documentação para eles em `stories/tokens/core/breakpointTokens.stories.mdx`. Como o [addon de tokens que usamos](https://github.com/UX-and-I/storybook-design-token) não tem um presenter pronto para tokens de breakpoint, usei o nosso `CustomDesignTokenDocBlock`
* Adaptei o `CustomDesignTokenDocBlock` para funcionar com tokens de breakpoint, não mostrando um preview nesse caso (não vi uma forma de fazer um preview relevante desse tipo de token)

# Como testar
* Rodar o Storybook e ver que os tokens de breakpoint estão documentados:
<img width="1832" alt="Screenshot 2025-02-28 at 11 11 30" src="https://github.com/user-attachments/assets/9205af0a-c825-41fc-a485-4ca3d2221e62" />

* Atualizar o DS no SGLearner e ver que é possível usar os tokens: https://phabricator.geekie.com.br/D29055 (diff em andamento)