### PR TITLE
Cria helpers para media queries com os breakpoints

### DIFF
--- a/helpers/breakpointHelpers.ts
+++ b/helpers/breakpointHelpers.ts
@@ -6,7 +6,7 @@ export const getMinWidthMediaQuery = (breakpoint: number): string =>
   // the min and max queries are consistent for a screen with width equal to the breakpoint.
   `@media (min-width: ${breakpoint + 1}px)`;
 
-export const getInBetweenWidthMediaQuery = (
+export const getInBetweenWidthsMediaQuery = (
   minBreakpoint: number,
   maxBreakpoint: number
 ): string =>

--- a/helpers/breakpointHelpers.ts
+++ b/helpers/breakpointHelpers.ts
@@ -1,4 +1,4 @@
-export const getMaxWidthMediaQuery = (breakpoint: number) : string =>
+export const getMaxWidthMediaQuery = (breakpoint: number): string =>
   `@media (max-width: ${breakpoint}px)`;
 
 export const getMinWidthMediaQuery = (breakpoint: number): string =>

--- a/helpers/breakpointHelpers.ts
+++ b/helpers/breakpointHelpers.ts
@@ -1,0 +1,15 @@
+export const getMaxWidthMediaQuery = (breakpoint: number) : string =>
+  `@media (max-width: ${breakpoint}px)`;
+
+export const getMinWidthMediaQuery = (breakpoint: number): string =>
+  // Since both the min and max width queries are inclusive, we add 1 to the breakpoint here so that
+  // the min and max queries are consistent for a screen with width equal to the breakpoint.
+  `@media (min-width: ${breakpoint + 1}px)`;
+
+export const getInBetweenWidthMediaQuery = (
+  minBreakpoint: number,
+  maxBreakpoint: number
+): string =>
+  `@media (min-width: ${
+    minBreakpoint + 1
+  }px) and (max-width: ${maxBreakpoint}px)`;

--- a/stories/tokens/core/breakpointTokens.stories.mdx
+++ b/stories/tokens/core/breakpointTokens.stories.mdx
@@ -22,7 +22,7 @@ Para facilitar o uso e seguir a regra de inclusividade, existem 3 helpers que cr
 
 - `getMaxWidthMediaQuery(breakpoint)`: para estilos destinados a telas com `largura <= breakpoint`
 - `getMinWidthMediaQuery(breakpoint)`: para estilos destinados a telas com `largura > breakpoint`
-- `getInBetweenWidthsMediaQuery(minBreakpoint, maxBreakpoint)`: para estilos destinados a telas com `minBreakpoint <= largura < maxBreakpoint`
+- `getInBetweenWidthsMediaQuery(minBreakpoint, maxBreakpoint)`: para estilos destinados a telas com `minBreakpoint < largura <= maxBreakpoint`
 
 Segue um exemplo de uso, na stylesheet do SGLearner:
 

--- a/stories/tokens/core/breakpointTokens.stories.mdx
+++ b/stories/tokens/core/breakpointTokens.stories.mdx
@@ -15,3 +15,31 @@ import breakpointTokens from '../../../tokens/src/core/breakpoint.json';
     value: `${breakpointTokens.breakpoint[size].value}px`,
   }))}
 />
+
+Os breakpoints são pontos de corte para alterar o layout da tela de acordo com sua largura. Eles são inclusivos na extremidade superior mas não na inferior: por exemplo, uma tela com largura de 1200 px (igual ao DSA_BREAKPOINT_LARGE) teria a mesma aparência de uma tela com largura de 1199 px, e a diferença passaria a acontecer a partir de 1201 px.
+
+Para facilitar o uso e seguir a regra de inclusividade, existem 3 helpers que criam media queries a partir dos breakpoints:
+
+* `getMaxWidthMediaQuery(breakpoint)`: para estilos destinados a telas com `largura <= breakpoint`
+* `getMinWidthMediaQuery(breakpoint)`: para estilos destinados a telas com `largura > breakpoint`
+* `getInBetweenWidthMediaQuery(minBreakpoint, maxBreakpoint)`: para estilos destinados a telas com `minBreakpoint <= largura < maxBreakpoint`
+
+Segue um exemplo de uso, na stylesheet do SGLearner:
+
+```
+weekDropdownMenu: {
+  position: 'absolute',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  top: 18,
+  right: 48,
+
+  [getMaxWidthMediaQuery(designSystem.DSA_BREAKPOINT_LARGE)]: {
+    position: 'static',
+    marginTop: 16,
+  },
+},
+```
+
+Dessa forma, o estilo com `{ position: 'static', marginTop: 16 }` vai ser aplicado apenas em telas que tenham largura de no máximo `DSA_BREAKPOINT_LARGE` (1200 px, inclusive).

--- a/stories/tokens/core/breakpointTokens.stories.mdx
+++ b/stories/tokens/core/breakpointTokens.stories.mdx
@@ -22,7 +22,7 @@ Para facilitar o uso e seguir a regra de inclusividade, existem 3 helpers que cr
 
 - `getMaxWidthMediaQuery(breakpoint)`: para estilos destinados a telas com `largura <= breakpoint`
 - `getMinWidthMediaQuery(breakpoint)`: para estilos destinados a telas com `largura > breakpoint`
-- `getInBetweenWidthMediaQuery(minBreakpoint, maxBreakpoint)`: para estilos destinados a telas com `minBreakpoint <= largura < maxBreakpoint`
+- `getInBetweenWidthsMediaQuery(minBreakpoint, maxBreakpoint)`: para estilos destinados a telas com `minBreakpoint <= largura < maxBreakpoint`
 
 Segue um exemplo de uso, na stylesheet do SGLearner:
 

--- a/stories/tokens/core/breakpointTokens.stories.mdx
+++ b/stories/tokens/core/breakpointTokens.stories.mdx
@@ -35,7 +35,7 @@ weekDropdownMenu: {
   top: 18,
   right: 48,
 
-  [getMaxWidthMediaQuery(designSystem.DSA_BREAKPOINT_LARGE)]: {
+  [getMaxWidthMediaQuery(DSA_BREAKPOINT_LARGE)]: {
     position: 'static',
     marginTop: 16,
   },

--- a/stories/tokens/core/breakpointTokens.stories.mdx
+++ b/stories/tokens/core/breakpointTokens.stories.mdx
@@ -20,9 +20,9 @@ Os breakpoints são pontos de corte para alterar o layout da tela de acordo com 
 
 Para facilitar o uso e seguir a regra de inclusividade, existem 3 helpers que criam media queries a partir dos breakpoints:
 
-* `getMaxWidthMediaQuery(breakpoint)`: para estilos destinados a telas com `largura <= breakpoint`
-* `getMinWidthMediaQuery(breakpoint)`: para estilos destinados a telas com `largura > breakpoint`
-* `getInBetweenWidthMediaQuery(minBreakpoint, maxBreakpoint)`: para estilos destinados a telas com `minBreakpoint <= largura < maxBreakpoint`
+- `getMaxWidthMediaQuery(breakpoint)`: para estilos destinados a telas com `largura <= breakpoint`
+- `getMinWidthMediaQuery(breakpoint)`: para estilos destinados a telas com `largura > breakpoint`
+- `getInBetweenWidthMediaQuery(minBreakpoint, maxBreakpoint)`: para estilos destinados a telas com `minBreakpoint <= largura < maxBreakpoint`
 
 Segue um exemplo de uso, na stylesheet do SGLearner:
 

--- a/tokens.ts
+++ b/tokens.ts
@@ -1,5 +1,6 @@
 export * from './built-tokens/js/tokens';
 export * from './built-tokens/js/semantic-tokens';
 
+export * from './helpers/breakpointHelpers';
 export * from './helpers/webOnlyHelpers';
 export * from './themes/getThemeToken';


### PR DESCRIPTION
# Contexto
No PR #49 criei os tokens de breakpoints. Para facilitar a criação de media queries e também uniformizar o tratamento das extremidades dos intervalos definidos pelos breakpoints, achei que valia a pena criar helpers que criam media queries a partir dos breakpoints.

Sobre o comportamento das extremidades (o caso de telas com largura idêntica a um breakpoint): [alinhei com o Cássio](https://geekie.slack.com/archives/C08CRP0S0EL/p1740762065858979?thread_ts=1739889871.734069&cid=C08CRP0S0EL) de convencionar que os intervalos são inclusivos na extremidade superior e exclusivos na extremidade inferior.

# Mudanças
* Criei os helpers num arquivo `helpers/breakpointHelpers.ts`
* Documentei o uso dos helpers no `breakpointTokens.stories.mdx`

# Como testar

* Validar que é possível usar os helpers no SGLearner (diff em andamento: https://phabricator.geekie.com.br/D29055)
* Ver a documentação aparecendo no Storybook:

<img width="1816" alt="Screenshot 2025-02-28 at 16 53 48" src="https://github.com/user-attachments/assets/a86256cf-c776-4845-9e77-a59d5cf5819b" />

